### PR TITLE
Ubuntu ARM64 の CI を有効化し、c_char の型不一致を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
           sudo apt-get install -y build-essential \
             libclang-dev \
             libx11-dev
+      - name: Install Clang for ARM64
+        if: runner.os == 'Linux' && runner.arch == 'ARM64'
+        run: |
+          sudo apt-get install -y clang
       - run: rustup update stable
       - uses: shiguredo/github-actions/.github/actions/rust-cache@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,12 @@ jobs:
           sudo apt-get install -y build-essential \
             libclang-dev \
             libx11-dev
-      - name: Install Clang for ARM64
+      - name: Install Clang 20 for ARM64
         if: runner.os == 'Linux' && runner.arch == 'ARM64'
         run: |
-          sudo apt-get install -y clang
+          wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 20
+          sudo ln -sf /usr/bin/clang-20 /usr/bin/clang
+          sudo ln -sf /usr/bin/clang++-20 /usr/bin/clang++
       - run: rustup update stable
       - uses: shiguredo/github-actions/.github/actions/rust-cache@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
           - ubuntu-22.04
           - macos-26
           - macos-15
+          - ubuntu-24.04-arm
+          - ubuntu-22.04-arm
           # 将来的に対応予定
-          # - ubuntu-24.04-arm
-          # - ubuntu-22.04-arm
           # - windows-2025
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,12 @@ jobs:
           sudo apt-get install -y build-essential \
             libclang-dev \
             libx11-dev
-      - name: Install Clang 20 for ARM64
+      - name: Install Clang 21 for ARM64
         if: runner.os == 'Linux' && runner.arch == 'ARM64'
         run: |
-          wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 20
-          sudo ln -sf /usr/bin/clang-20 /usr/bin/clang
-          sudo ln -sf /usr/bin/clang++-20 /usr/bin/clang++
+          wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 21
+          sudo ln -sf /usr/bin/clang-21 /usr/bin/clang
+          sudo ln -sf /usr/bin/clang++-21 /usr/bin/clang++
       - run: rustup update stable
       - uses: shiguredo/github-actions/.github/actions/rust-cache@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
           sudo apt-get install -y build-essential \
             libclang-dev \
             libx11-dev
+      # ARM64 Linux ではビルドに Clang 21 以上が必要なため、
+      # apt.llvm.org から Clang 21 をインストールし、clang / clang++ として使えるようにシンボリックリンクを作成する
       - name: Install Clang 21 for ARM64
         if: runner.os == 'Linux' && runner.arch == 'ARM64'
         run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 ## develop
 
+### ADD
+
+- Ubuntu 24.04 LTS arm64 / Ubuntu 22.04 LTS arm64 をサポート
+
 ### misc
 
 ## 0.145.0

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ libwebrtc の C API バインディングを Rust から安全に利用するた
 
 - Ubuntu 24.04 LTS x86_64
 - Ubuntu 22.04 LTS x86_64
+- Ubuntu 24.04 LTS arm64
+- Ubuntu 22.04 LTS arm64
 - macOS Tahoe 26 arm64
 - macOS Sequoia 15 arm64
 
@@ -42,8 +44,6 @@ libwebrtc の C API バインディングを Rust から安全に利用するた
 
 ### 将来対応予定
 
-- Ubuntu 24.04 LTS arm64
-- Ubuntu 22.04 LTS arm64
 - Windows 11 x86_64
 - Windows Server 2025 x86_64
 

--- a/src/api/jsep.rs
+++ b/src/api/jsep.rs
@@ -21,7 +21,7 @@ impl SdpParseError {
         let mut len = 0usize;
         unsafe { ffi::webrtc_SdpParseError_line(raw.as_ptr(), &mut ptr, &mut len) };
         assert!(!ptr.is_null());
-        let bytes = unsafe { slice::from_raw_parts(ptr as *const u8, len) };
+        let bytes = unsafe { slice::from_raw_parts(ptr.cast::<u8>(), len) };
         let line = std::str::from_utf8(bytes)?;
         Ok(line.to_owned())
     }
@@ -32,7 +32,7 @@ impl SdpParseError {
         let mut len = 0usize;
         unsafe { ffi::webrtc_SdpParseError_description(raw.as_ptr(), &mut ptr, &mut len) };
         assert!(!ptr.is_null());
-        let bytes = unsafe { slice::from_raw_parts(ptr as *const u8, len) };
+        let bytes = unsafe { slice::from_raw_parts(ptr.cast::<u8>(), len) };
         let description = std::str::from_utf8(bytes)?;
         Ok(description.to_owned())
     }

--- a/src/api/rtc_error.rs
+++ b/src/api/rtc_error.rs
@@ -27,7 +27,7 @@ impl RtcError {
         let mut len = 0usize;
         unsafe { ffi::webrtc_RTCError_message(raw.as_ptr(), &mut ptr, &mut len) };
         assert!(!ptr.is_null());
-        let bytes = unsafe { slice::from_raw_parts(ptr as *const u8, len) };
+        let bytes = unsafe { slice::from_raw_parts(ptr.cast::<u8>(), len) };
         let msg = std::str::from_utf8(bytes)?;
         Ok(msg.to_owned())
     }

--- a/src/cxxstd.rs
+++ b/src/cxxstd.rs
@@ -56,7 +56,7 @@ impl CxxString {
     pub fn to_string(&self) -> Result<String> {
         let raw = self.raw_string();
         let len = self.len();
-        let ptr = unsafe { ffi::std_string_c_str(raw.as_ptr()) } as *const u8;
+        let ptr = unsafe { ffi::std_string_c_str(raw.as_ptr()) }.cast::<u8>();
         assert!(!ptr.is_null(), "BUG: std_string_c_str が null を返しました");
         let bytes = unsafe { slice::from_raw_parts(ptr, len) };
         let s = std::str::from_utf8(bytes)?;
@@ -67,7 +67,7 @@ impl CxxString {
     pub fn to_bytes(&self) -> Vec<u8> {
         let raw = self.raw_string();
         let len = self.len();
-        let ptr = unsafe { ffi::std_string_c_str(raw.as_ptr()) } as *const u8;
+        let ptr = unsafe { ffi::std_string_c_str(raw.as_ptr()) }.cast::<u8>();
         unsafe { slice::from_raw_parts(ptr, len) }.to_vec()
     }
 
@@ -125,7 +125,7 @@ impl<'a> CxxStringRef<'a> {
     /// UTF-8 に変換できない場合はエラーを返す。
     pub fn to_string(&self) -> Result<String> {
         let len = self.len();
-        let ptr = unsafe { ffi::std_string_c_str(self.as_ptr()) } as *const u8;
+        let ptr = unsafe { ffi::std_string_c_str(self.as_ptr()) }.cast::<u8>();
         assert!(!ptr.is_null(), "BUG: std_string_c_str が null を返しました");
         let bytes = unsafe { slice::from_raw_parts(ptr, len) };
         let s = std::str::from_utf8(bytes)?;
@@ -135,7 +135,7 @@ impl<'a> CxxStringRef<'a> {
     /// バイト列として取得する。
     pub fn to_bytes(&self) -> Vec<u8> {
         let len = self.len();
-        let ptr = unsafe { ffi::std_string_c_str(self.as_ptr()) } as *const u8;
+        let ptr = unsafe { ffi::std_string_c_str(self.as_ptr()) }.cast::<u8>();
         unsafe { slice::from_raw_parts(ptr, len) }.to_vec()
     }
 

--- a/webrtc/CMakeLists.txt
+++ b/webrtc/CMakeLists.txt
@@ -137,20 +137,19 @@ set(LLVM_BUILDTOOLS_DIR "${LLVM_DIR}/buildtools")
 set(WEBRTC_CACHE_KEY "${WEBRTC_BUILD_VERSION}:${WEBRTC_C_TARGET}")
 set(WEBRTC_VERSION_FILE "${DEPS_DIR}/webrtc.version")
 set(LLVM_VERSION_FILE "${DEPS_DIR}/llvm.version")
-# Prebuilt Clang バイナリのダウンロードと使用
-set(WEBRTC_USE_PREBUILT_CLANG TRUE)
-# libc++ ヘッダーのダウンロードと使用（WebRTC との ABI 互換性のため）
-set(WEBRTC_USE_LIBCXX TRUE)
+# WebRTC 向けの Prebuilt Clang バイナリのダウンロードと使用
+set(WEBRTC_USE_WEBRTC_PREBUILT_CLANG TRUE)
+# WebRTC 向けの libc++ ヘッダーのダウンロードと使用（WebRTC との ABI 互換性のため）
+set(WEBRTC_USE_WEBRTC_LIBCXX TRUE)
 
 if(WEBRTC_C_TARGET STREQUAL "windows_x86_64")
-  set(WEBRTC_USE_PREBUILT_CLANG FALSE)
-  set(WEBRTC_USE_LIBCXX FALSE)
+  set(WEBRTC_USE_WEBRTC_PREBUILT_CLANG TRUE)
+  set(WEBRTC_USE_WEBRTC_LIBCXX FALSE)
 endif()
 
 # ARM64 Linux では prebuilt Clang バイナリが提供されていないためシステムの Clang を使用
-# libc++ ヘッダーは ABI 互換性のためダウンロードする
 if(WEBRTC_C_TARGET IN_LIST WEBRTC_TARGETS_ARMV8)
-  set(WEBRTC_USE_PREBUILT_CLANG FALSE)
+  set(WEBRTC_USE_WEBRTC_PREBUILT_CLANG FALSE)
 endif()
 
 # WebRTC のダウンロード（project() の前に実行）
@@ -208,7 +207,7 @@ set(LLVM_CACHE_KEY "${LLVM_VERSION_STRING}:${WEBRTC_C_TARGET}")
 
 # LLVM のダウンロード（project() の前に実行）
 set(LLVM_NEEDS_INSTALL TRUE)
-if((WEBRTC_USE_PREBUILT_CLANG OR WEBRTC_USE_LIBCXX) AND EXISTS "${LLVM_VERSION_FILE}")
+if((WEBRTC_USE_WEBRTC_PREBUILT_CLANG OR WEBRTC_USE_WEBRTC_LIBCXX) AND EXISTS "${LLVM_VERSION_FILE}")
   file(READ "${LLVM_VERSION_FILE}" LLVM_INSTALLED_VERSION)
   string(STRIP "${LLVM_INSTALLED_VERSION}" LLVM_INSTALLED_VERSION)
   if("${LLVM_INSTALLED_VERSION}" STREQUAL "${LLVM_CACHE_KEY}")
@@ -217,12 +216,12 @@ if((WEBRTC_USE_PREBUILT_CLANG OR WEBRTC_USE_LIBCXX) AND EXISTS "${LLVM_VERSION_F
   endif()
 endif()
 
-if((WEBRTC_USE_PREBUILT_CLANG OR WEBRTC_USE_LIBCXX) AND LLVM_NEEDS_INSTALL)
+if((WEBRTC_USE_WEBRTC_PREBUILT_CLANG OR WEBRTC_USE_WEBRTC_LIBCXX) AND LLVM_NEEDS_INSTALL)
   message(STATUS "Installing LLVM...")
   file(REMOVE_RECURSE "${LLVM_DIR}")
   file(MAKE_DIRECTORY "${LLVM_DIR}")
 
-  if(WEBRTC_USE_PREBUILT_CLANG)
+  if(WEBRTC_USE_WEBRTC_PREBUILT_CLANG)
     # tools を shallow clone
     message(STATUS "Cloning tools...")
     git_shallow_clone(
@@ -240,7 +239,7 @@ if((WEBRTC_USE_PREBUILT_CLANG OR WEBRTC_USE_LIBCXX) AND LLVM_NEEDS_INSTALL)
     )
   endif()
 
-  if(WEBRTC_USE_LIBCXX)
+  if(WEBRTC_USE_WEBRTC_LIBCXX)
     # libcxx を shallow clone
     message(STATUS "Cloning libcxx...")
     git_shallow_clone(
@@ -281,7 +280,7 @@ if(WEBRTC_USE_PREBUILT_CLANG)
   set(CMAKE_CXX_COMPILER "${LLVM_CLANG_DIR}/bin/clang++" CACHE FILEPATH "" FORCE)
   message(STATUS "CMAKE_C_COMPILER: ${CMAKE_C_COMPILER}")
   message(STATUS "CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}")
-elseif(WEBRTC_USE_LIBCXX)
+elseif(WEBRTC_USE_WEBRTC_LIBCXX)
   # libc++ を使用するがプリビルト Clang は使わない場合（ARM64 Linux）
   # ABI 互換性のためシステムの Clang を使用する
   find_program(SYSTEM_CLANG clang)
@@ -298,7 +297,7 @@ else()
   message(STATUS "WEBRTC_USE_PREBUILT_CLANG is OFF for target: ${WEBRTC_C_TARGET}")
 endif()
 
-if(WEBRTC_USE_LIBCXX)
+if(WEBRTC_USE_WEBRTC_LIBCXX)
   set(LIBCXX_INCLUDE_DIR "${LLVM_LIBCXX_DIR}/include")
   message(STATUS "LIBCXX_INCLUDE_DIR: ${LIBCXX_INCLUDE_DIR}")
 endif()
@@ -387,7 +386,7 @@ endforeach()
 
 set(BUNDLE_STATIC_LIBS ${WEBRTC_LIBRARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}webrtc${CMAKE_STATIC_LIBRARY_SUFFIX})
 
-if(WEBRTC_USE_LIBCXX)
+if(WEBRTC_USE_WEBRTC_LIBCXX)
   # libc++ の設定（WebRTC と同じ libc++ ヘッダーを使用）
   foreach(target IN LISTS WEBRTC_CPP_TARGETS)
     target_compile_options(${target}

--- a/webrtc/CMakeLists.txt
+++ b/webrtc/CMakeLists.txt
@@ -274,7 +274,7 @@ if((WEBRTC_USE_WEBRTC_PREBUILT_CLANG OR WEBRTC_USE_WEBRTC_LIBCXX) AND LLVM_NEEDS
   message(STATUS "LLVM installation complete")
 endif()
 
-if(WEBRTC_USE_PREBUILT_CLANG)
+if(WEBRTC_USE_WEBRTC_PREBUILT_CLANG)
   # Prebuilt Clang コンパイラのパスを設定（project() の前）
   set(CMAKE_C_COMPILER "${LLVM_CLANG_DIR}/bin/clang" CACHE FILEPATH "" FORCE)
   set(CMAKE_CXX_COMPILER "${LLVM_CLANG_DIR}/bin/clang++" CACHE FILEPATH "" FORCE)
@@ -294,7 +294,7 @@ elseif(WEBRTC_USE_WEBRTC_LIBCXX)
     message(FATAL_ERROR "System Clang is required for ARM64 Linux but not found. Install with: apt install clang")
   endif()
 else()
-  message(STATUS "WEBRTC_USE_PREBUILT_CLANG is OFF for target: ${WEBRTC_C_TARGET}")
+  message(STATUS "WEBRTC_USE_WEBRTC_PREBUILT_CLANG is OFF for target: ${WEBRTC_C_TARGET}")
 endif()
 
 if(WEBRTC_USE_WEBRTC_LIBCXX)

--- a/webrtc/CMakeLists.txt
+++ b/webrtc/CMakeLists.txt
@@ -94,6 +94,17 @@ endif()
 message(STATUS "WEBRTC_C_TARGET: ${WEBRTC_C_TARGET}")
 message(STATUS "WEBRTC_BUILD_VERSION: ${WEBRTC_BUILD_VERSION}")
 
+set(WEBRTC_TARGETS_UBUNTU
+  "ubuntu-24.04_x86_64"
+  "ubuntu-24.04_armv8"
+  "ubuntu-22.04_x86_64"
+  "ubuntu-22.04_armv8"
+)
+set(WEBRTC_TARGETS_ARMV8
+  "ubuntu-24.04_armv8"
+  "ubuntu-22.04_armv8"
+)
+
 # WebRTC パッケージの URL を決定
 if(WEBRTC_C_TARGET STREQUAL "macos_arm64")
   set(WEBRTC_ARCHIVE_NAME "webrtc.macos_arm64.tar.gz")
@@ -138,7 +149,7 @@ endif()
 
 # ARM64 Linux では prebuilt Clang バイナリが提供されていないためシステムの Clang を使用
 # libc++ ヘッダーは ABI 互換性のためダウンロードする
-if(WEBRTC_C_TARGET MATCHES "armv8$")
+if(WEBRTC_C_TARGET IN_LIST WEBRTC_TARGETS_ARMV8)
   set(WEBRTC_USE_PREBUILT_CLANG FALSE)
 endif()
 
@@ -532,7 +543,7 @@ elseif (WEBRTC_C_TARGET STREQUAL "macos_arm64")
     )
   endforeach()
 
-elseif (WEBRTC_C_TARGET MATCHES "^ubuntu-")
+elseif (WEBRTC_C_TARGET IN_LIST WEBRTC_TARGETS_UBUNTU)
   foreach(target IN LISTS WEBRTC_CPP_TARGETS)
     target_compile_definitions(${target}
       PRIVATE
@@ -640,7 +651,7 @@ elseif (WEBRTC_C_TARGET STREQUAL "macos_arm64")
         "-framework ScreenCaptureKit"
     )
   endforeach()
-elseif (WEBRTC_C_TARGET MATCHES "^ubuntu-")
+elseif (WEBRTC_C_TARGET IN_LIST WEBRTC_TARGETS_UBUNTU)
   foreach(target IN LISTS WEBRTC_C_TARGETS)
     target_link_libraries(${target} PRIVATE X11 dl rt Threads::Threads)
   endforeach()

--- a/webrtc/CMakeLists.txt
+++ b/webrtc/CMakeLists.txt
@@ -126,9 +126,20 @@ set(LLVM_BUILDTOOLS_DIR "${LLVM_DIR}/buildtools")
 set(WEBRTC_CACHE_KEY "${WEBRTC_BUILD_VERSION}:${WEBRTC_C_TARGET}")
 set(WEBRTC_VERSION_FILE "${DEPS_DIR}/webrtc.version")
 set(LLVM_VERSION_FILE "${DEPS_DIR}/llvm.version")
-set(WEBRTC_USE_PREBUILT_LLVM TRUE)
+# Prebuilt Clang バイナリのダウンロードと使用
+set(WEBRTC_USE_PREBUILT_CLANG TRUE)
+# libc++ ヘッダーのダウンロードと使用（WebRTC との ABI 互換性のため）
+set(WEBRTC_USE_LIBCXX TRUE)
+
 if(WEBRTC_C_TARGET STREQUAL "windows_x86_64")
-  set(WEBRTC_USE_PREBUILT_LLVM FALSE)
+  set(WEBRTC_USE_PREBUILT_CLANG FALSE)
+  set(WEBRTC_USE_LIBCXX FALSE)
+endif()
+
+# ARM64 Linux では prebuilt Clang バイナリが提供されていないためシステムの Clang を使用
+# libc++ ヘッダーは ABI 互換性のためダウンロードする
+if(WEBRTC_C_TARGET MATCHES "armv8$")
+  set(WEBRTC_USE_PREBUILT_CLANG FALSE)
 endif()
 
 # WebRTC のダウンロード（project() の前に実行）
@@ -186,7 +197,7 @@ set(LLVM_CACHE_KEY "${LLVM_VERSION_STRING}:${WEBRTC_C_TARGET}")
 
 # LLVM のダウンロード（project() の前に実行）
 set(LLVM_NEEDS_INSTALL TRUE)
-if(WEBRTC_USE_PREBUILT_LLVM AND EXISTS "${LLVM_VERSION_FILE}")
+if((WEBRTC_USE_PREBUILT_CLANG OR WEBRTC_USE_LIBCXX) AND EXISTS "${LLVM_VERSION_FILE}")
   file(READ "${LLVM_VERSION_FILE}" LLVM_INSTALLED_VERSION)
   string(STRIP "${LLVM_INSTALLED_VERSION}" LLVM_INSTALLED_VERSION)
   if("${LLVM_INSTALLED_VERSION}" STREQUAL "${LLVM_CACHE_KEY}")
@@ -195,71 +206,90 @@ if(WEBRTC_USE_PREBUILT_LLVM AND EXISTS "${LLVM_VERSION_FILE}")
   endif()
 endif()
 
-if(WEBRTC_USE_PREBUILT_LLVM AND LLVM_NEEDS_INSTALL)
+if((WEBRTC_USE_PREBUILT_CLANG OR WEBRTC_USE_LIBCXX) AND LLVM_NEEDS_INSTALL)
   message(STATUS "Installing LLVM...")
   file(REMOVE_RECURSE "${LLVM_DIR}")
   file(MAKE_DIRECTORY "${LLVM_DIR}")
 
-  # tools を shallow clone
-  message(STATUS "Cloning tools...")
-  git_shallow_clone(
-    NAME "tools"
-    WORKING_DIRECTORY "${LLVM_TOOLS_DIR}"
-    REPOSITORY "${WEBRTC_WEBRTC_SRC_TOOLS_URL}"
-    COMMIT "${WEBRTC_WEBRTC_SRC_TOOLS_COMMIT}"
-  )
+  if(WEBRTC_USE_PREBUILT_CLANG)
+    # tools を shallow clone
+    message(STATUS "Cloning tools...")
+    git_shallow_clone(
+      NAME "tools"
+      WORKING_DIRECTORY "${LLVM_TOOLS_DIR}"
+      REPOSITORY "${WEBRTC_WEBRTC_SRC_TOOLS_URL}"
+      COMMIT "${WEBRTC_WEBRTC_SRC_TOOLS_COMMIT}"
+    )
 
-  # update.py を実行して Clang をダウンロード
-  message(STATUS "Downloading Clang via update.py...")
-  execute_process_checked(
-    COMMAND python3 "${LLVM_TOOLS_DIR}/clang/scripts/update.py" --output-dir "${LLVM_CLANG_DIR}"
-    ERROR_MESSAGE "Failed to download Clang"
-  )
-
-  # libcxx を shallow clone
-  message(STATUS "Cloning libcxx...")
-  git_shallow_clone(
-    NAME "libcxx"
-    WORKING_DIRECTORY "${LLVM_LIBCXX_DIR}"
-    REPOSITORY "${WEBRTC_WEBRTC_SRC_THIRD_PARTY_LIBCXX_SRC_URL}"
-    COMMIT "${WEBRTC_WEBRTC_SRC_THIRD_PARTY_LIBCXX_SRC_COMMIT}"
-  )
-
-  # buildtools を shallow clone
-  message(STATUS "Cloning buildtools...")
-  git_shallow_clone(
-    NAME "buildtools"
-    WORKING_DIRECTORY "${LLVM_BUILDTOOLS_DIR}"
-    REPOSITORY "${WEBRTC_WEBRTC_SRC_BUILDTOOLS_URL}"
-    COMMIT "${WEBRTC_WEBRTC_SRC_BUILDTOOLS_COMMIT}"
-  )
-
-  # __config_site と __assertion_handler をコピー
-  message(STATUS "Copying libc++ config files...")
-  file(COPY "${LLVM_BUILDTOOLS_DIR}/third_party/libc++/__config_site" DESTINATION "${LLVM_LIBCXX_DIR}/include")
-  file(COPY "${LLVM_BUILDTOOLS_DIR}/third_party/libc++/__assertion_handler" DESTINATION "${LLVM_LIBCXX_DIR}/include")
-  if(NOT EXISTS "${LLVM_LIBCXX_DIR}/include/__config_site")
-    message(FATAL_ERROR "Failed to copy __config_site")
+    # update.py を実行して Clang をダウンロード
+    message(STATUS "Downloading Clang via update.py...")
+    execute_process_checked(
+      COMMAND python3 "${LLVM_TOOLS_DIR}/clang/scripts/update.py" --output-dir "${LLVM_CLANG_DIR}"
+      ERROR_MESSAGE "Failed to download Clang"
+    )
   endif()
-  if(NOT EXISTS "${LLVM_LIBCXX_DIR}/include/__assertion_handler")
-    message(FATAL_ERROR "Failed to copy __assertion_handler")
+
+  if(WEBRTC_USE_LIBCXX)
+    # libcxx を shallow clone
+    message(STATUS "Cloning libcxx...")
+    git_shallow_clone(
+      NAME "libcxx"
+      WORKING_DIRECTORY "${LLVM_LIBCXX_DIR}"
+      REPOSITORY "${WEBRTC_WEBRTC_SRC_THIRD_PARTY_LIBCXX_SRC_URL}"
+      COMMIT "${WEBRTC_WEBRTC_SRC_THIRD_PARTY_LIBCXX_SRC_COMMIT}"
+    )
+
+    # buildtools を shallow clone
+    message(STATUS "Cloning buildtools...")
+    git_shallow_clone(
+      NAME "buildtools"
+      WORKING_DIRECTORY "${LLVM_BUILDTOOLS_DIR}"
+      REPOSITORY "${WEBRTC_WEBRTC_SRC_BUILDTOOLS_URL}"
+      COMMIT "${WEBRTC_WEBRTC_SRC_BUILDTOOLS_COMMIT}"
+    )
+
+    # __config_site と __assertion_handler をコピー
+    message(STATUS "Copying libc++ config files...")
+    file(COPY "${LLVM_BUILDTOOLS_DIR}/third_party/libc++/__config_site" DESTINATION "${LLVM_LIBCXX_DIR}/include")
+    file(COPY "${LLVM_BUILDTOOLS_DIR}/third_party/libc++/__assertion_handler" DESTINATION "${LLVM_LIBCXX_DIR}/include")
+    if(NOT EXISTS "${LLVM_LIBCXX_DIR}/include/__config_site")
+      message(FATAL_ERROR "Failed to copy __config_site")
+    endif()
+    if(NOT EXISTS "${LLVM_LIBCXX_DIR}/include/__assertion_handler")
+      message(FATAL_ERROR "Failed to copy __assertion_handler")
+    endif()
   endif()
 
   file(WRITE "${LLVM_VERSION_FILE}" "${LLVM_CACHE_KEY}")
   message(STATUS "LLVM installation complete")
 endif()
 
-if(WEBRTC_USE_PREBUILT_LLVM)
-  # Clang コンパイラのパスを設定（project() の前）
+if(WEBRTC_USE_PREBUILT_CLANG)
+  # Prebuilt Clang コンパイラのパスを設定（project() の前）
   set(CMAKE_C_COMPILER "${LLVM_CLANG_DIR}/bin/clang" CACHE FILEPATH "" FORCE)
   set(CMAKE_CXX_COMPILER "${LLVM_CLANG_DIR}/bin/clang++" CACHE FILEPATH "" FORCE)
-  set(LIBCXX_INCLUDE_DIR "${LLVM_LIBCXX_DIR}/include")
-
   message(STATUS "CMAKE_C_COMPILER: ${CMAKE_C_COMPILER}")
   message(STATUS "CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}")
-  message(STATUS "LIBCXX_INCLUDE_DIR: ${LIBCXX_INCLUDE_DIR}")
+elseif(WEBRTC_USE_LIBCXX)
+  # libc++ を使用するがプリビルト Clang は使わない場合（ARM64 Linux）
+  # ABI 互換性のためシステムの Clang を使用する
+  find_program(SYSTEM_CLANG clang)
+  find_program(SYSTEM_CLANGPP clang++)
+  if(SYSTEM_CLANG AND SYSTEM_CLANGPP)
+    set(CMAKE_C_COMPILER "${SYSTEM_CLANG}" CACHE FILEPATH "" FORCE)
+    set(CMAKE_CXX_COMPILER "${SYSTEM_CLANGPP}" CACHE FILEPATH "" FORCE)
+    message(STATUS "Using system Clang: ${SYSTEM_CLANG}")
+    message(STATUS "Using system Clang++: ${SYSTEM_CLANGPP}")
+  else()
+    message(FATAL_ERROR "System Clang is required for ARM64 Linux but not found. Install with: apt install clang")
+  endif()
 else()
-  message(STATUS "WEBRTC_USE_PREBUILT_LLVM is OFF for target: ${WEBRTC_C_TARGET}")
+  message(STATUS "WEBRTC_USE_PREBUILT_CLANG is OFF for target: ${WEBRTC_C_TARGET}")
+endif()
+
+if(WEBRTC_USE_LIBCXX)
+  set(LIBCXX_INCLUDE_DIR "${LLVM_LIBCXX_DIR}/include")
+  message(STATUS "LIBCXX_INCLUDE_DIR: ${LIBCXX_INCLUDE_DIR}")
 endif()
 
 # ここで project() を呼び出す
@@ -346,8 +376,8 @@ endforeach()
 
 set(BUNDLE_STATIC_LIBS ${WEBRTC_LIBRARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}webrtc${CMAKE_STATIC_LIBRARY_SUFFIX})
 
-if(WEBRTC_USE_PREBUILT_LLVM)
-  # libc++ の設定（LLVM の libc++ を使用）
+if(WEBRTC_USE_LIBCXX)
+  # libc++ の設定（WebRTC と同じ libc++ ヘッダーを使用）
   foreach(target IN LISTS WEBRTC_CPP_TARGETS)
     target_compile_options(${target}
       PRIVATE


### PR DESCRIPTION
- CI マトリクスに ubuntu-24.04-arm / ubuntu-22.04-arm を追加
- ARM64 Linux では c_char が u8 のため、ハードコードされた i8 を c_char に置換