### PR TITLE
prebuilt ダウンロードを curl + tar に変更する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [UPDATE] prebuilt ダウンロードに rustls / flate2 / tar クレートの代わりに curl + tar コマンドを利用する
+  - @voluntas
 - [UPDATE] cmake の代わりに shiguredo_cmake を利用する
   - @melpon
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -29,9 +23,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
  "cc",
  "cmake",
@@ -169,15 +163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,41 +195,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "filetime"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "fs_extra"
@@ -349,23 +303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
-dependencies = [
- "bitflags",
- "libc",
- "redox_syscall",
-]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,16 +319,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
 
 [[package]]
 name = "noargs"
@@ -442,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -454,15 +381,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d94dd2f7cd932d4dc02cc8b2b50dfd38bd079a4e5d79198b99743d7fcf9a4b4"
-dependencies = [
- "bitflags",
-]
 
 [[package]]
 name = "regex"
@@ -512,19 +430,6 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "rustls"
@@ -680,12 +585,7 @@ name = "shiguredo_webrtc"
 version = "0.145.3-canary.1"
 dependencies = [
  "bindgen",
- "flate2",
- "rustls",
- "rustls-platform-verifier",
  "shiguredo_cmake",
- "shiguredo_http11",
- "tar",
 ]
 
 [[package]]
@@ -693,12 +593,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "subtle"
@@ -715,17 +609,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "tar"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
 ]
 
 [[package]]
@@ -996,16 +879,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-
-[[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix",
-]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,15 +29,6 @@ source-build = []
 
 [build-dependencies]
 bindgen = "0.72"
-flate2 = "1"
-rustls = { version = "0.23", default-features = false, features = [
-    "std",
-    "tls12",
-    "aws-lc-rs",
-] }
-rustls-platform-verifier = "0.6"
-shiguredo_http11 = "2026.1.0"
-tar = "0.4"
 shiguredo_cmake = "4.2.3"
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -329,13 +329,15 @@ impl FactoryHolder {
 必要なもの:
 
 - Rust 1.88 以上
+- `curl` (prebuilt ダウンロードに使用)
+- `tar` (prebuilt 展開に使用)
 - Linux の場合: `libx11-dev` (リンク時に必要)
 
 ```bash
 # Linux
-sudo apt-get install libx11-dev
+sudo apt-get install curl tar libx11-dev
 
-# macOS は追加のインストール不要
+# macOS は curl と tar がプリインストール済みのため追加インストール不要
 ```
 
 ### ソースビルド

--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,6 @@
 use std::env;
 use std::fs;
-use std::io::{Cursor, Read, Write};
-use std::net::TcpStream;
-use std::path::{Component, Path, PathBuf};
-use std::sync::Arc;
-
-use rustls::pki_types::ServerName;
-use rustls::{ClientConfig, ClientConnection, StreamOwned};
-use rustls_platform_verifier::ConfigVerifierExt;
-use shiguredo_http11::{DecoderLimits, Request, Response, ResponseDecoder};
+use std::path::{Path, PathBuf};
 
 fn main() {
     // Cargo.toml か build.rs が更新されたら、依存ライブラリを再ビルドする
@@ -91,11 +83,14 @@ fn download_prebuilt(target: &str, out_dir: &Path) -> Result<PrebuiltPaths, Stri
 
     eprintln!("prebuilt ライブラリをダウンロード中: {}", url);
 
-    let archive_bytes = fetch_url(&url)?;
-
     // OUT_DIR/prebuilt/ に展開
     let prebuilt_dir = out_dir.join("prebuilt");
-    extract_tar_gz_from_bytes(&archive_bytes, &prebuilt_dir)?;
+    let archive_path = out_dir.join("libwebrtc_c.tar.gz");
+    download(&url, &archive_path)?;
+    fs::create_dir_all(&prebuilt_dir)
+        .map_err(|e| format!("展開先ディレクトリ作成に失敗: {}", e))?;
+    extract(&archive_path, &prebuilt_dir)?;
+    let _ = fs::remove_file(&archive_path);
 
     // libwebrtc_c.a を OUT_DIR/lib/ にコピー
     let lib_dir = out_dir.join("lib");
@@ -115,33 +110,32 @@ fn download_prebuilt(target: &str, out_dir: &Path) -> Result<PrebuiltPaths, Stri
     Ok(PrebuiltPaths { lib_path })
 }
 
-/// バイト列から tar.gz を展開する
-fn extract_tar_gz_from_bytes(data: &[u8], dest_dir: &Path) -> Result<(), String> {
-    fs::create_dir_all(dest_dir).map_err(|e| format!("展開先ディレクトリ作成に失敗: {}", e))?;
-    let decoder = flate2::read::GzDecoder::new(Cursor::new(data));
-    let mut archive = tar::Archive::new(decoder);
-    let entries = archive
-        .entries()
-        .map_err(|e| format!("tar エントリ取得に失敗: {}", e))?;
-
-    for entry in entries {
-        let mut entry = entry.map_err(|e| format!("tar エントリ読み込みに失敗: {}", e))?;
-        let path = entry
-            .path()
-            .map_err(|e| format!("tar パス取得に失敗: {}", e))?;
-        if !is_safe_path(&path) {
-            return Err(format!("不正なパスが含まれています: {}", path.display()));
-        }
-        let out_path = dest_dir.join(&*path);
-        if let Some(parent) = out_path.parent() {
-            fs::create_dir_all(parent)
-                .map_err(|e| format!("展開先ディレクトリ作成に失敗: {}", e))?;
-        }
-        entry
-            .unpack(&out_path)
-            .map_err(|e| format!("tar 展開に失敗: {}", e))?;
+/// curl を使ってファイルをダウンロードする
+fn download(url: &str, output: &Path) -> Result<(), String> {
+    let status = std::process::Command::new("curl")
+        .args(["-fSL", "--retry", "3", "-o"])
+        .arg(output)
+        .arg(url)
+        .status()
+        .map_err(|e| format!("curl の実行に失敗しました: {}", e))?;
+    if !status.success() {
+        return Err(format!("ダウンロードに失敗しました: {}", url));
     }
+    Ok(())
+}
 
+/// tar を使ってアーカイブを展開する
+fn extract(archive: &Path, dest: &Path) -> Result<(), String> {
+    let status = std::process::Command::new("tar")
+        .arg("xzf")
+        .arg(archive)
+        .arg("-C")
+        .arg(dest)
+        .status()
+        .map_err(|e| format!("tar の実行に失敗しました: {}", e))?;
+    if !status.success() {
+        return Err(format!("展開に失敗しました: {}", archive.display()));
+    }
     Ok(())
 }
 
@@ -275,190 +269,6 @@ fn remove_symlink(link_path: &Path) -> std::io::Result<()> {
 #[cfg(windows)]
 fn remove_symlink(link_path: &Path) -> std::io::Result<()> {
     fs::remove_dir(link_path)
-}
-
-fn is_safe_path(path: &Path) -> bool {
-    for component in path.components() {
-        match component {
-            Component::Prefix(_) | Component::RootDir | Component::ParentDir => return false,
-            _ => {}
-        }
-    }
-    true
-}
-
-fn fetch_url(url: &str) -> Result<Vec<u8>, String> {
-    let mut current = url.to_string();
-    for _ in 0..5 {
-        let response = fetch_url_once(&current)?;
-        if response.is_redirect() {
-            let location = response
-                .get_header("Location")
-                .ok_or_else(|| "Location ヘッダーがありません".to_string())?;
-            current = resolve_redirect_url(&current, location)?;
-            continue;
-        }
-        if response.status_code != 200 {
-            return Err(format!(
-                "HTTP エラー : {} {} ({})",
-                response.status_code, response.reason_phrase, current
-            ));
-        }
-        return Ok(response.body);
-    }
-
-    Err(format!("リダイレクトが多すぎます : {}", url))
-}
-
-fn fetch_url_once(url: &str) -> Result<Response, String> {
-    let (scheme, host, port, path) = parse_url(url)?;
-    let request = Request::new("GET", &path)
-        .header("Host", &host)
-        .header("User-Agent", "shiguredo_webrtc-build")
-        .header("Accept", "*/*")
-        .header("Connection", "close");
-    let request_bytes = request.encode();
-    if scheme == "https" {
-        https_request(&host, port, &request_bytes)
-    } else {
-        http_request(&host, port, &request_bytes)
-    }
-}
-
-fn parse_url(url: &str) -> Result<(String, String, u16, String), String> {
-    let (scheme, rest) = if let Some(rest) = url.strip_prefix("https://") {
-        ("https".to_string(), rest)
-    } else if let Some(rest) = url.strip_prefix("http://") {
-        ("http".to_string(), rest)
-    } else {
-        return Err(format!("URL が不正です : {}", url));
-    };
-
-    let (host_port, path) = match rest.find('/') {
-        Some(index) => (&rest[..index], &rest[index..]),
-        None => (rest, "/"),
-    };
-
-    let (host, port) = match host_port.find(':') {
-        Some(index) => {
-            let port: u16 = host_port[index + 1..]
-                .parse()
-                .map_err(|e| format!("ポートの解析に失敗しました : {}", e))?;
-            (&host_port[..index], port)
-        }
-        None => {
-            let port = if scheme == "https" { 443 } else { 80 };
-            (host_port, port)
-        }
-    };
-
-    Ok((scheme, host.to_string(), port, path.to_string()))
-}
-
-fn resolve_redirect_url(current_url: &str, location: &str) -> Result<String, String> {
-    if location.starts_with("http://") || location.starts_with("https://") {
-        return Ok(location.to_string());
-    }
-
-    let (scheme, host, port, path) = parse_url(current_url)?;
-    let host_port = if (scheme == "https" && port == 443) || (scheme == "http" && port == 80) {
-        host
-    } else {
-        format!("{}:{}", host, port)
-    };
-
-    if location.starts_with('/') {
-        return Ok(format!("{}://{}{}", scheme, host_port, location));
-    }
-
-    let base = match path.rfind('/') {
-        Some(pos) => &path[..=pos],
-        None => "/",
-    };
-    Ok(format!("{}://{}{}{}", scheme, host_port, base, location))
-}
-
-fn http_request(host: &str, port: u16, request_bytes: &[u8]) -> Result<Response, String> {
-    let mut stream =
-        TcpStream::connect((host, port)).map_err(|e| format!("HTTP 接続に失敗しました : {}", e))?;
-    stream
-        .write_all(request_bytes)
-        .map_err(|e| format!("HTTP リクエスト送信に失敗しました : {}", e))?;
-
-    let mut decoder = ResponseDecoder::with_limits(DecoderLimits::unlimited());
-    let mut buf = [0u8; 8192];
-
-    loop {
-        let n = stream
-            .read(&mut buf)
-            .map_err(|e| format!("HTTP レスポンス受信に失敗しました : {}", e))?;
-        if n == 0 {
-            decoder.mark_eof();
-            if let Some(response) = decoder
-                .decode()
-                .map_err(|e| format!("HTTP レスポンス解析に失敗しました : {}", e))?
-            {
-                return Ok(response);
-            }
-            return Err("HTTP レスポンスの受信が完了しませんでした".to_string());
-        }
-        decoder
-            .feed(&buf[..n])
-            .map_err(|e| format!("HTTP レスポンス解析に失敗しました : {}", e))?;
-        if let Some(response) = decoder
-            .decode()
-            .map_err(|e| format!("HTTP レスポンス解析に失敗しました : {}", e))?
-        {
-            return Ok(response);
-        }
-    }
-}
-
-fn https_request(host: &str, port: u16, request_bytes: &[u8]) -> Result<Response, String> {
-    let config = ClientConfig::with_platform_verifier()
-        .map_err(|e| format!("TLS 設定の作成に失敗しました : {}", e))?;
-    let server_name = ServerName::try_from(host.to_string())
-        .map_err(|e| format!("サーバー名の解析に失敗しました : {}", e))?;
-    let conn = ClientConnection::new(Arc::new(config), server_name)
-        .map_err(|e| format!("TLS 接続に失敗しました : {}", e))?;
-    let sock = TcpStream::connect((host, port))
-        .map_err(|e| format!("HTTPS 接続に失敗しました : {}", e))?;
-    let mut tls = StreamOwned::new(conn, sock);
-
-    tls.write_all(request_bytes)
-        .map_err(|e| format!("HTTPS リクエスト送信に失敗しました : {}", e))?;
-
-    let mut decoder = ResponseDecoder::with_limits(DecoderLimits::unlimited());
-    let mut buf = [0u8; 8192];
-
-    loop {
-        let n = match tls.read(&mut buf) {
-            Ok(0) => {
-                decoder.mark_eof();
-                if let Some(response) = decoder
-                    .decode()
-                    .map_err(|e| format!("HTTPS レスポンス解析に失敗しました : {}", e))?
-                {
-                    return Ok(response);
-                }
-                return Err("HTTPS レスポンスの受信が完了しませんでした".to_string());
-            }
-            Ok(n) => n,
-            Err(err) => {
-                return Err(format!("HTTPS レスポンス受信に失敗しました : {}", err));
-            }
-        };
-
-        decoder
-            .feed(&buf[..n])
-            .map_err(|e| format!("HTTPS レスポンス解析に失敗しました : {}", e))?;
-        if let Some(response) = decoder
-            .decode()
-            .map_err(|e| format!("HTTPS レスポンス解析に失敗しました : {}", e))?
-        {
-            return Ok(response);
-        }
-    }
 }
 
 fn generate_bindings(header: &Path, include_dir: &Path) {


### PR DESCRIPTION
独自の HTTP/HTTPS 実装（shiguredo_http11 + rustls）と tar/flate2 クレートを 外部コマンドの curl と tar に置き換える。
build-dependencies が 5 クレート削減されシンプルになる。