### PR TITLE
色々な修正

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,12 @@
 
 ## develop
 
+- [CHANGE] VideoEncoder / VideoDecoder の API を handler と 1 対 1 に統一する
+  - `VideoEncoder::init_encode` / `encode` / `set_rates` を handler と同じ引数に統一する
+  - `VideoDecoder::configure` / `decode` を handler と同じ引数に統一する
+  - `VideoEncoder::init_encode()` / `VideoEncoder::set_rates()` / `VideoDecoder::configure()` の 0 引数 API を削除する
+  - `webrtc_GetDefaultVideoFormats` と `get_default_video_formats` を削除し、`webrtc-c` の独自 convenience API をなくす
+  - @melpon
 - [CHANGE] VideoEncoder / VideoDecoder / factory の callback API を handler trait 形式に変更する
   - `VideoEncoderHandler` / `VideoDecoderHandler` / `VideoEncoderFactoryHandler` / `VideoDecoderFactoryHandler` / `VideoEncoderEncodedImageCallbackHandler` を追加する
   - `new_with_callbacks` を `new_with_handler` に変更する
@@ -24,6 +30,16 @@
 - [CHANGE] libyuv 変換 API 名を libyuv と 1 対 1 に統一する
   - `i420_to_argb` を削除し、`convert_from_i420` と `LibyuvFourcc` を追加する
   - `i420_to_nv12` を追加する
+  - @melpon
+- [ADD] `SdpVideoFormat` の parameters / scalability modes を扱う API を追加する
+  - `ScalabilityMode` 型を追加する
+  - `SdpVideoFormat::new_with_parameters` と `SdpVideoFormat::scalability_modes` を追加する
+  - `SdpVideoFormatRef::scalability_modes` を追加する
+  - @melpon
+- [ADD] `VideoCodecType` の文字列変換 API を追加する
+  - `VideoCodecType::as_str`
+  - `TryFrom<&str> for VideoCodecType`
+  - `FromStr for VideoCodecType`
   - @melpon
 - [UPDATE] libwebrtc m146 (m146.7680.0.0) に上げる
   - @voluntas

--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ impl FactoryHolder {
 
 - `VideoCodecRef` / `VideoCodecType` / `VideoCodecStatus`
   - 映像コーデック共通型とステータス
+- `ScalabilityMode`
+  - スケーラビリティーモード
 - `VideoFrameType` / `VideoFrameTypeVector` / `VideoFrameTypeVectorRef`
   - エンコード対象フレーム種別
 - `EncodedImageBuffer` / `EncodedImage` / `EncodedImageRef`

--- a/src/api/video_codec_common.rs
+++ b/src/api/video_codec_common.rs
@@ -60,37 +60,23 @@ impl ScalabilityMode {
                 x if x == ffi::webrtc_ScalabilityMode_L1T3 => Some(Self::L1T3),
                 x if x == ffi::webrtc_ScalabilityMode_L2T1 => Some(Self::L2T1),
                 x if x == ffi::webrtc_ScalabilityMode_L2T1h => Some(Self::L2T1h),
-                x if x == ffi::webrtc_ScalabilityMode_L2T1_KEY => {
-                    Some(Self::L2T1Key)
-                }
+                x if x == ffi::webrtc_ScalabilityMode_L2T1_KEY => Some(Self::L2T1Key),
                 x if x == ffi::webrtc_ScalabilityMode_L2T2 => Some(Self::L2T2),
                 x if x == ffi::webrtc_ScalabilityMode_L2T2h => Some(Self::L2T2h),
-                x if x == ffi::webrtc_ScalabilityMode_L2T2_KEY => {
-                    Some(Self::L2T2Key)
-                }
-                x if x == ffi::webrtc_ScalabilityMode_L2T2_KEY_SHIFT => {
-                    Some(Self::L2T2KeyShift)
-                }
+                x if x == ffi::webrtc_ScalabilityMode_L2T2_KEY => Some(Self::L2T2Key),
+                x if x == ffi::webrtc_ScalabilityMode_L2T2_KEY_SHIFT => Some(Self::L2T2KeyShift),
                 x if x == ffi::webrtc_ScalabilityMode_L2T3 => Some(Self::L2T3),
                 x if x == ffi::webrtc_ScalabilityMode_L2T3h => Some(Self::L2T3h),
-                x if x == ffi::webrtc_ScalabilityMode_L2T3_KEY => {
-                    Some(Self::L2T3Key)
-                }
+                x if x == ffi::webrtc_ScalabilityMode_L2T3_KEY => Some(Self::L2T3Key),
                 x if x == ffi::webrtc_ScalabilityMode_L3T1 => Some(Self::L3T1),
                 x if x == ffi::webrtc_ScalabilityMode_L3T1h => Some(Self::L3T1h),
-                x if x == ffi::webrtc_ScalabilityMode_L3T1_KEY => {
-                    Some(Self::L3T1Key)
-                }
+                x if x == ffi::webrtc_ScalabilityMode_L3T1_KEY => Some(Self::L3T1Key),
                 x if x == ffi::webrtc_ScalabilityMode_L3T2 => Some(Self::L3T2),
                 x if x == ffi::webrtc_ScalabilityMode_L3T2h => Some(Self::L3T2h),
-                x if x == ffi::webrtc_ScalabilityMode_L3T2_KEY => {
-                    Some(Self::L3T2Key)
-                }
+                x if x == ffi::webrtc_ScalabilityMode_L3T2_KEY => Some(Self::L3T2Key),
                 x if x == ffi::webrtc_ScalabilityMode_L3T3 => Some(Self::L3T3),
                 x if x == ffi::webrtc_ScalabilityMode_L3T3h => Some(Self::L3T3h),
-                x if x == ffi::webrtc_ScalabilityMode_L3T3_KEY => {
-                    Some(Self::L3T3Key)
-                }
+                x if x == ffi::webrtc_ScalabilityMode_L3T3_KEY => Some(Self::L3T3Key),
                 x if x == ffi::webrtc_ScalabilityMode_S2T1 => Some(Self::S2T1),
                 x if x == ffi::webrtc_ScalabilityMode_S2T1h => Some(Self::S2T1h),
                 x if x == ffi::webrtc_ScalabilityMode_S2T2 => Some(Self::S2T2),

--- a/src/api/video_codec_common.rs
+++ b/src/api/video_codec_common.rs
@@ -52,96 +52,100 @@ impl ScalabilityMode {
         CxxString::from_unique(raw).to_string()
     }
 
-    fn from_raw(value: ffi::webrtc_ScalabilityMode) -> Option<Self> {
-        match value {
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L1T1 => Some(Self::L1T1),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L1T2 => Some(Self::L1T2),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L1T3 => Some(Self::L1T3),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T1 => Some(Self::L2T1),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T1h => Some(Self::L2T1h),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T1_KEY => {
-                Some(Self::L2T1Key)
+    fn from_raw(value: i32) -> Option<Self> {
+        unsafe {
+            match value {
+                x if x == ffi::webrtc_ScalabilityMode_L1T1 => Some(Self::L1T1),
+                x if x == ffi::webrtc_ScalabilityMode_L1T2 => Some(Self::L1T2),
+                x if x == ffi::webrtc_ScalabilityMode_L1T3 => Some(Self::L1T3),
+                x if x == ffi::webrtc_ScalabilityMode_L2T1 => Some(Self::L2T1),
+                x if x == ffi::webrtc_ScalabilityMode_L2T1h => Some(Self::L2T1h),
+                x if x == ffi::webrtc_ScalabilityMode_L2T1_KEY => {
+                    Some(Self::L2T1Key)
+                }
+                x if x == ffi::webrtc_ScalabilityMode_L2T2 => Some(Self::L2T2),
+                x if x == ffi::webrtc_ScalabilityMode_L2T2h => Some(Self::L2T2h),
+                x if x == ffi::webrtc_ScalabilityMode_L2T2_KEY => {
+                    Some(Self::L2T2Key)
+                }
+                x if x == ffi::webrtc_ScalabilityMode_L2T2_KEY_SHIFT => {
+                    Some(Self::L2T2KeyShift)
+                }
+                x if x == ffi::webrtc_ScalabilityMode_L2T3 => Some(Self::L2T3),
+                x if x == ffi::webrtc_ScalabilityMode_L2T3h => Some(Self::L2T3h),
+                x if x == ffi::webrtc_ScalabilityMode_L2T3_KEY => {
+                    Some(Self::L2T3Key)
+                }
+                x if x == ffi::webrtc_ScalabilityMode_L3T1 => Some(Self::L3T1),
+                x if x == ffi::webrtc_ScalabilityMode_L3T1h => Some(Self::L3T1h),
+                x if x == ffi::webrtc_ScalabilityMode_L3T1_KEY => {
+                    Some(Self::L3T1Key)
+                }
+                x if x == ffi::webrtc_ScalabilityMode_L3T2 => Some(Self::L3T2),
+                x if x == ffi::webrtc_ScalabilityMode_L3T2h => Some(Self::L3T2h),
+                x if x == ffi::webrtc_ScalabilityMode_L3T2_KEY => {
+                    Some(Self::L3T2Key)
+                }
+                x if x == ffi::webrtc_ScalabilityMode_L3T3 => Some(Self::L3T3),
+                x if x == ffi::webrtc_ScalabilityMode_L3T3h => Some(Self::L3T3h),
+                x if x == ffi::webrtc_ScalabilityMode_L3T3_KEY => {
+                    Some(Self::L3T3Key)
+                }
+                x if x == ffi::webrtc_ScalabilityMode_S2T1 => Some(Self::S2T1),
+                x if x == ffi::webrtc_ScalabilityMode_S2T1h => Some(Self::S2T1h),
+                x if x == ffi::webrtc_ScalabilityMode_S2T2 => Some(Self::S2T2),
+                x if x == ffi::webrtc_ScalabilityMode_S2T2h => Some(Self::S2T2h),
+                x if x == ffi::webrtc_ScalabilityMode_S2T3 => Some(Self::S2T3),
+                x if x == ffi::webrtc_ScalabilityMode_S2T3h => Some(Self::S2T3h),
+                x if x == ffi::webrtc_ScalabilityMode_S3T1 => Some(Self::S3T1),
+                x if x == ffi::webrtc_ScalabilityMode_S3T1h => Some(Self::S3T1h),
+                x if x == ffi::webrtc_ScalabilityMode_S3T2 => Some(Self::S3T2),
+                x if x == ffi::webrtc_ScalabilityMode_S3T2h => Some(Self::S3T2h),
+                x if x == ffi::webrtc_ScalabilityMode_S3T3 => Some(Self::S3T3),
+                x if x == ffi::webrtc_ScalabilityMode_S3T3h => Some(Self::S3T3h),
+                _ => None,
             }
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T2 => Some(Self::L2T2),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T2h => Some(Self::L2T2h),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T2_KEY => {
-                Some(Self::L2T2Key)
-            }
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T2_KEY_SHIFT => {
-                Some(Self::L2T2KeyShift)
-            }
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T3 => Some(Self::L2T3),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T3h => Some(Self::L2T3h),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T3_KEY => {
-                Some(Self::L2T3Key)
-            }
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T1 => Some(Self::L3T1),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T1h => Some(Self::L3T1h),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T1_KEY => {
-                Some(Self::L3T1Key)
-            }
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T2 => Some(Self::L3T2),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T2h => Some(Self::L3T2h),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T2_KEY => {
-                Some(Self::L3T2Key)
-            }
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T3 => Some(Self::L3T3),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T3h => Some(Self::L3T3h),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T3_KEY => {
-                Some(Self::L3T3Key)
-            }
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T1 => Some(Self::S2T1),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T1h => Some(Self::S2T1h),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T2 => Some(Self::S2T2),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T2h => Some(Self::S2T2h),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T3 => Some(Self::S2T3),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T3h => Some(Self::S2T3h),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T1 => Some(Self::S3T1),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T1h => Some(Self::S3T1h),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T2 => Some(Self::S3T2),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T2h => Some(Self::S3T2h),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T3 => Some(Self::S3T3),
-            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T3h => Some(Self::S3T3h),
-            _ => None,
         }
     }
 
-    fn to_raw(self) -> ffi::webrtc_ScalabilityMode {
-        match self {
-            Self::L1T1 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L1T1,
-            Self::L1T2 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L1T2,
-            Self::L1T3 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L1T3,
-            Self::L2T1 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T1,
-            Self::L2T1h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T1h,
-            Self::L2T1Key => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T1_KEY,
-            Self::L2T2 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T2,
-            Self::L2T2h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T2h,
-            Self::L2T2Key => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T2_KEY,
-            Self::L2T2KeyShift => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T2_KEY_SHIFT,
-            Self::L2T3 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T3,
-            Self::L2T3h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T3h,
-            Self::L2T3Key => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T3_KEY,
-            Self::L3T1 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T1,
-            Self::L3T1h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T1h,
-            Self::L3T1Key => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T1_KEY,
-            Self::L3T2 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T2,
-            Self::L3T2h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T2h,
-            Self::L3T2Key => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T2_KEY,
-            Self::L3T3 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T3,
-            Self::L3T3h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T3h,
-            Self::L3T3Key => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T3_KEY,
-            Self::S2T1 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T1,
-            Self::S2T1h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T1h,
-            Self::S2T2 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T2,
-            Self::S2T2h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T2h,
-            Self::S2T3 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T3,
-            Self::S2T3h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T3h,
-            Self::S3T1 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T1,
-            Self::S3T1h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T1h,
-            Self::S3T2 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T2,
-            Self::S3T2h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T2h,
-            Self::S3T3 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T3,
-            Self::S3T3h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T3h,
+    fn to_raw(self) -> i32 {
+        unsafe {
+            match self {
+                Self::L1T1 => ffi::webrtc_ScalabilityMode_L1T1,
+                Self::L1T2 => ffi::webrtc_ScalabilityMode_L1T2,
+                Self::L1T3 => ffi::webrtc_ScalabilityMode_L1T3,
+                Self::L2T1 => ffi::webrtc_ScalabilityMode_L2T1,
+                Self::L2T1h => ffi::webrtc_ScalabilityMode_L2T1h,
+                Self::L2T1Key => ffi::webrtc_ScalabilityMode_L2T1_KEY,
+                Self::L2T2 => ffi::webrtc_ScalabilityMode_L2T2,
+                Self::L2T2h => ffi::webrtc_ScalabilityMode_L2T2h,
+                Self::L2T2Key => ffi::webrtc_ScalabilityMode_L2T2_KEY,
+                Self::L2T2KeyShift => ffi::webrtc_ScalabilityMode_L2T2_KEY_SHIFT,
+                Self::L2T3 => ffi::webrtc_ScalabilityMode_L2T3,
+                Self::L2T3h => ffi::webrtc_ScalabilityMode_L2T3h,
+                Self::L2T3Key => ffi::webrtc_ScalabilityMode_L2T3_KEY,
+                Self::L3T1 => ffi::webrtc_ScalabilityMode_L3T1,
+                Self::L3T1h => ffi::webrtc_ScalabilityMode_L3T1h,
+                Self::L3T1Key => ffi::webrtc_ScalabilityMode_L3T1_KEY,
+                Self::L3T2 => ffi::webrtc_ScalabilityMode_L3T2,
+                Self::L3T2h => ffi::webrtc_ScalabilityMode_L3T2h,
+                Self::L3T2Key => ffi::webrtc_ScalabilityMode_L3T2_KEY,
+                Self::L3T3 => ffi::webrtc_ScalabilityMode_L3T3,
+                Self::L3T3h => ffi::webrtc_ScalabilityMode_L3T3h,
+                Self::L3T3Key => ffi::webrtc_ScalabilityMode_L3T3_KEY,
+                Self::S2T1 => ffi::webrtc_ScalabilityMode_S2T1,
+                Self::S2T1h => ffi::webrtc_ScalabilityMode_S2T1h,
+                Self::S2T2 => ffi::webrtc_ScalabilityMode_S2T2,
+                Self::S2T2h => ffi::webrtc_ScalabilityMode_S2T2h,
+                Self::S2T3 => ffi::webrtc_ScalabilityMode_S2T3,
+                Self::S2T3h => ffi::webrtc_ScalabilityMode_S2T3h,
+                Self::S3T1 => ffi::webrtc_ScalabilityMode_S3T1,
+                Self::S3T1h => ffi::webrtc_ScalabilityMode_S3T1h,
+                Self::S3T2 => ffi::webrtc_ScalabilityMode_S3T2,
+                Self::S3T2h => ffi::webrtc_ScalabilityMode_S3T2h,
+                Self::S3T3 => ffi::webrtc_ScalabilityMode_S3T3,
+                Self::S3T3h => ffi::webrtc_ScalabilityMode_S3T3h,
+            }
         }
     }
 }
@@ -263,7 +267,7 @@ impl<'a> SdpVideoFormatRef<'a> {
         if len == 0 {
             return Vec::new();
         }
-        let mut raw_modes = vec![ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L1T1; len];
+        let mut raw_modes = vec![unsafe { ffi::webrtc_ScalabilityMode_L1T1 }; len];
         let copied = unsafe {
             ffi::webrtc_SdpVideoFormat_copy_scalability_modes(
                 self.raw.as_ptr(),

--- a/src/api/video_codec_common.rs
+++ b/src/api/video_codec_common.rs
@@ -1,7 +1,6 @@
 use crate::ref_count::{EncodedImageBufferHandle, I420BufferHandle};
-use crate::{CxxString, CxxStringRef, MapStringString, Result, ScopedRef, ffi};
+use crate::{CxxString, CxxStringRef, Error, MapStringString, Result, ScopedRef, ffi};
 use std::collections::HashMap;
-use std::fmt;
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 use std::slice;
@@ -662,17 +661,6 @@ pub enum VideoCodecType {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ParseVideoCodecTypeError;
-
-impl fmt::Display for ParseVideoCodecTypeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("invalid video codec type")
-    }
-}
-
-impl std::error::Error for ParseVideoCodecTypeError {}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VideoCodecStatus {
     TargetBitrateOvershoot,
     OkRequestKeyframe,
@@ -790,9 +778,9 @@ impl VideoCodecType {
 }
 
 impl TryFrom<&str> for VideoCodecType {
-    type Error = ParseVideoCodecTypeError;
+    type Error = Error;
 
-    fn try_from(value: &str) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: &str) -> Result<Self> {
         match value {
             "Generic" => Ok(Self::Generic),
             "VP8" => Ok(Self::Vp8),
@@ -800,15 +788,15 @@ impl TryFrom<&str> for VideoCodecType {
             "AV1" => Ok(Self::Av1),
             "H264" => Ok(Self::H264),
             "H265" => Ok(Self::H265),
-            _ => Err(ParseVideoCodecTypeError),
+            _ => Err(Error::InvalidVideoCodecType(value.to_string())),
         }
     }
 }
 
 impl std::str::FromStr for VideoCodecType {
-    type Err = ParseVideoCodecTypeError;
+    type Err = Error;
 
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self> {
         Self::try_from(s)
     }
 }

--- a/src/api/video_codec_common.rs
+++ b/src/api/video_codec_common.rs
@@ -1,8 +1,150 @@
 use crate::ref_count::{EncodedImageBufferHandle, I420BufferHandle};
-use crate::{CxxStringRef, MapStringString, Result, ScopedRef, ffi};
+use crate::{CxxString, CxxStringRef, MapStringString, Result, ScopedRef, ffi};
+use std::collections::HashMap;
+use std::fmt;
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 use std::slice;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ScalabilityMode {
+    L1T1,
+    L1T2,
+    L1T3,
+    L2T1,
+    L2T1h,
+    L2T1Key,
+    L2T2,
+    L2T2h,
+    L2T2Key,
+    L2T2KeyShift,
+    L2T3,
+    L2T3h,
+    L2T3Key,
+    L3T1,
+    L3T1h,
+    L3T1Key,
+    L3T2,
+    L3T2h,
+    L3T2Key,
+    L3T3,
+    L3T3h,
+    L3T3Key,
+    S2T1,
+    S2T1h,
+    S2T2,
+    S2T2h,
+    S2T3,
+    S2T3h,
+    S3T1,
+    S3T1h,
+    S3T2,
+    S3T2h,
+    S3T3,
+    S3T3h,
+}
+
+impl ScalabilityMode {
+    pub fn as_str(self) -> Result<String> {
+        let raw = unsafe { ffi::webrtc_ScalabilityModeToString(self.to_raw()) };
+        let raw =
+            NonNull::new(raw).expect("BUG: webrtc_ScalabilityModeToString が null を返しました");
+        CxxString::from_unique(raw).to_string()
+    }
+
+    fn from_raw(value: ffi::webrtc_ScalabilityMode) -> Option<Self> {
+        match value {
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L1T1 => Some(Self::L1T1),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L1T2 => Some(Self::L1T2),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L1T3 => Some(Self::L1T3),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T1 => Some(Self::L2T1),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T1h => Some(Self::L2T1h),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T1_KEY => {
+                Some(Self::L2T1Key)
+            }
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T2 => Some(Self::L2T2),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T2h => Some(Self::L2T2h),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T2_KEY => {
+                Some(Self::L2T2Key)
+            }
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T2_KEY_SHIFT => {
+                Some(Self::L2T2KeyShift)
+            }
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T3 => Some(Self::L2T3),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T3h => Some(Self::L2T3h),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T3_KEY => {
+                Some(Self::L2T3Key)
+            }
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T1 => Some(Self::L3T1),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T1h => Some(Self::L3T1h),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T1_KEY => {
+                Some(Self::L3T1Key)
+            }
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T2 => Some(Self::L3T2),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T2h => Some(Self::L3T2h),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T2_KEY => {
+                Some(Self::L3T2Key)
+            }
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T3 => Some(Self::L3T3),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T3h => Some(Self::L3T3h),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T3_KEY => {
+                Some(Self::L3T3Key)
+            }
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T1 => Some(Self::S2T1),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T1h => Some(Self::S2T1h),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T2 => Some(Self::S2T2),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T2h => Some(Self::S2T2h),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T3 => Some(Self::S2T3),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T3h => Some(Self::S2T3h),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T1 => Some(Self::S3T1),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T1h => Some(Self::S3T1h),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T2 => Some(Self::S3T2),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T2h => Some(Self::S3T2h),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T3 => Some(Self::S3T3),
+            x if x == ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T3h => Some(Self::S3T3h),
+            _ => None,
+        }
+    }
+
+    fn to_raw(self) -> ffi::webrtc_ScalabilityMode {
+        match self {
+            Self::L1T1 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L1T1,
+            Self::L1T2 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L1T2,
+            Self::L1T3 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L1T3,
+            Self::L2T1 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T1,
+            Self::L2T1h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T1h,
+            Self::L2T1Key => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T1_KEY,
+            Self::L2T2 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T2,
+            Self::L2T2h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T2h,
+            Self::L2T2Key => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T2_KEY,
+            Self::L2T2KeyShift => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T2_KEY_SHIFT,
+            Self::L2T3 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T3,
+            Self::L2T3h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T3h,
+            Self::L2T3Key => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L2T3_KEY,
+            Self::L3T1 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T1,
+            Self::L3T1h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T1h,
+            Self::L3T1Key => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T1_KEY,
+            Self::L3T2 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T2,
+            Self::L3T2h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T2h,
+            Self::L3T2Key => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T2_KEY,
+            Self::L3T3 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T3,
+            Self::L3T3h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T3h,
+            Self::L3T3Key => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L3T3_KEY,
+            Self::S2T1 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T1,
+            Self::S2T1h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T1h,
+            Self::S2T2 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T2,
+            Self::S2T2h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T2h,
+            Self::S2T3 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T3,
+            Self::S2T3h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S2T3h,
+            Self::S3T1 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T1,
+            Self::S3T1h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T1h,
+            Self::S3T2 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T2,
+            Self::S3T2h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T2h,
+            Self::S3T3 => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T3,
+            Self::S3T3h => ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_S3T3h,
+        }
+    }
+}
 
 pub struct SdpVideoFormat {
     raw_unique: NonNull<ffi::webrtc_SdpVideoFormat_unique>,
@@ -10,17 +152,44 @@ pub struct SdpVideoFormat {
 
 impl SdpVideoFormat {
     pub fn new(name: &str) -> Self {
-        let raw = unsafe {
-            ffi::webrtc_SdpVideoFormat_new(
-                name.as_ptr() as *const _,
-                name.len(),
-                std::ptr::null_mut(),
-            )
-        };
+        let raw = unsafe { ffi::webrtc_SdpVideoFormat_new(name.as_ptr() as *const _, name.len()) };
         Self {
             raw_unique: NonNull::new(raw)
                 .expect("BUG: webrtc_SdpVideoFormat_new が null を返しました"),
         }
+    }
+
+    pub fn new_with_parameters(
+        name: &str,
+        parameters: &HashMap<String, String>,
+        scalability_modes: &[ScalabilityMode],
+    ) -> Self {
+        let raw_modes = scalability_modes
+            .iter()
+            .copied()
+            .map(ScalabilityMode::to_raw)
+            .collect::<Vec<_>>();
+        let raw = unsafe {
+            ffi::webrtc_SdpVideoFormat_new_with_parameters(
+                name.as_ptr() as *const _,
+                name.len(),
+                std::ptr::null_mut(),
+                if raw_modes.is_empty() {
+                    std::ptr::null()
+                } else {
+                    raw_modes.as_ptr()
+                },
+                raw_modes.len(),
+            )
+        };
+        let mut format = Self {
+            raw_unique: NonNull::new(raw)
+                .expect("BUG: webrtc_SdpVideoFormat_new_with_parameters が null を返しました"),
+        };
+        for (key, value) in parameters {
+            format.parameters_mut().set(key.as_str(), value.as_str());
+        }
+        format
     }
 
     pub fn name(&self) -> Result<String> {
@@ -33,6 +202,10 @@ impl SdpVideoFormat {
 
     pub fn is_equal(&self, other: SdpVideoFormatRef<'_>) -> bool {
         unsafe { ffi::webrtc_SdpVideoFormat_is_equal(self.raw().as_ptr(), other.raw.as_ptr()) != 0 }
+    }
+
+    pub fn scalability_modes(&self) -> Vec<ScalabilityMode> {
+        self.as_ref().scalability_modes()
     }
 
     pub fn as_ref(&self) -> SdpVideoFormatRef<'_> {
@@ -82,6 +255,27 @@ impl<'a> SdpVideoFormatRef<'a> {
     pub fn parameters_mut(&mut self) -> MapStringString<'a> {
         let ptr = unsafe { ffi::webrtc_SdpVideoFormat_get_parameters(self.raw.as_ptr()) };
         MapStringString::from_raw(NonNull::new(ptr).expect("BUG: ptr が null"))
+    }
+
+    pub fn scalability_modes(&self) -> Vec<ScalabilityMode> {
+        let len =
+            unsafe { ffi::webrtc_SdpVideoFormat_get_scalability_modes_size(self.raw.as_ptr()) };
+        if len == 0 {
+            return Vec::new();
+        }
+        let mut raw_modes = vec![ffi::webrtc_ScalabilityMode_webrtc_ScalabilityMode_L1T1; len];
+        let copied = unsafe {
+            ffi::webrtc_SdpVideoFormat_copy_scalability_modes(
+                self.raw.as_ptr(),
+                raw_modes.as_mut_ptr(),
+                raw_modes.len(),
+            )
+        };
+        raw_modes
+            .into_iter()
+            .take(copied)
+            .filter_map(ScalabilityMode::from_raw)
+            .collect()
     }
 
     pub(crate) fn as_ptr(&self) -> *mut ffi::webrtc_SdpVideoFormat {
@@ -478,6 +672,17 @@ pub enum VideoCodecType {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseVideoCodecTypeError;
+
+impl fmt::Display for ParseVideoCodecTypeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("invalid video codec type")
+    }
+}
+
+impl std::error::Error for ParseVideoCodecTypeError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VideoCodecStatus {
     TargetBitrateOvershoot,
     OkRequestKeyframe,
@@ -551,6 +756,18 @@ impl VideoCodecStatus {
 }
 
 impl VideoCodecType {
+    pub fn as_str(self) -> Option<&'static str> {
+        match self {
+            Self::Generic => Some("Generic"),
+            Self::Vp8 => Some("VP8"),
+            Self::Vp9 => Some("VP9"),
+            Self::Av1 => Some("AV1"),
+            Self::H264 => Some("H264"),
+            Self::H265 => Some("H265"),
+            Self::Unknown(_) => None,
+        }
+    }
+
     pub(crate) fn from_raw(value: i32) -> Self {
         if value == unsafe { ffi::webrtc_VideoCodecType_Generic } {
             Self::Generic
@@ -579,6 +796,30 @@ impl VideoCodecType {
             Self::H265 => unsafe { ffi::webrtc_VideoCodecType_H265 },
             Self::Unknown(v) => v,
         }
+    }
+}
+
+impl TryFrom<&str> for VideoCodecType {
+    type Error = ParseVideoCodecTypeError;
+
+    fn try_from(value: &str) -> std::result::Result<Self, Self::Error> {
+        match value {
+            "Generic" => Ok(Self::Generic),
+            "VP8" => Ok(Self::Vp8),
+            "VP9" => Ok(Self::Vp9),
+            "AV1" => Ok(Self::Av1),
+            "H264" => Ok(Self::H264),
+            "H265" => Ok(Self::H265),
+            _ => Err(ParseVideoCodecTypeError),
+        }
+    }
+}
+
+impl std::str::FromStr for VideoCodecType {
+    type Err = ParseVideoCodecTypeError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Self::try_from(s)
     }
 }
 
@@ -619,6 +860,10 @@ impl<'a> VideoCodecRef<'a> {
 
     pub fn max_framerate(&self) -> u32 {
         unsafe { ffi::webrtc_VideoCodec_max_framerate(self.raw.as_ptr()) }
+    }
+
+    pub(crate) fn as_ptr(&self) -> *mut ffi::webrtc_VideoCodec {
+        self.raw.as_ptr()
     }
 }
 

--- a/src/api/video_decoder.rs
+++ b/src/api/video_decoder.rs
@@ -113,6 +113,10 @@ impl<'a> VideoDecoderSettingsRef<'a> {
     pub fn max_render_resolution_height(&self) -> i32 {
         unsafe { ffi::webrtc_VideoDecoder_Settings_max_render_resolution_height(self.raw.as_ptr()) }
     }
+
+    pub(crate) fn as_ptr(&self) -> *mut ffi::webrtc_VideoDecoder_Settings {
+        self.raw.as_ptr()
+    }
 }
 
 unsafe impl<'a> Send for VideoDecoderSettingsRef<'a> {}
@@ -405,19 +409,34 @@ impl VideoDecoder {
         std::mem::ManuallyDrop::new(self).raw_unique.as_ptr()
     }
 
-    pub fn configure(&mut self) -> bool {
-        unsafe { ffi::webrtc_VideoDecoder_Configure(self.as_ptr(), std::ptr::null_mut()) != 0 }
+    pub fn configure(&mut self, settings: VideoDecoderSettingsRef<'_>) -> bool {
+        unsafe { ffi::webrtc_VideoDecoder_Configure(self.as_ptr(), settings.as_ptr()) != 0 }
     }
 
     pub fn decode(
         &mut self,
-        input_image: Option<EncodedImageRef<'_>>,
+        input_image: EncodedImageRef<'_>,
         render_time_ms: i64,
     ) -> VideoCodecStatus {
-        let input_image =
-            input_image.map_or(std::ptr::null_mut(), |input_image| input_image.as_ptr());
-        let value =
-            unsafe { ffi::webrtc_VideoDecoder_Decode(self.as_ptr(), input_image, render_time_ms) };
+        let value = unsafe {
+            ffi::webrtc_VideoDecoder_Decode(self.as_ptr(), input_image.as_ptr(), render_time_ms)
+        };
+        VideoCodecStatus::from_raw(value)
+    }
+
+    pub fn register_decode_complete_callback(
+        &mut self,
+        callback: Option<VideoDecoderDecodedImageCallbackPtr>,
+    ) -> VideoCodecStatus {
+        let callback = callback.map_or(std::ptr::null_mut(), |callback| callback.raw.as_ptr());
+        let value = unsafe {
+            ffi::webrtc_VideoDecoder_RegisterDecodeCompleteCallback(self.as_ptr(), callback)
+        };
+        VideoCodecStatus::from_raw(value)
+    }
+
+    pub fn release(&mut self) -> VideoCodecStatus {
+        let value = unsafe { ffi::webrtc_VideoDecoder_Release(self.as_ptr()) };
         VideoCodecStatus::from_raw(value)
     }
 
@@ -429,11 +448,42 @@ impl VideoDecoder {
     }
 }
 
+impl VideoDecoderHandler for VideoDecoder {
+    fn configure(&mut self, settings: VideoDecoderSettingsRef<'_>) -> bool {
+        VideoDecoder::configure(self, settings)
+    }
+
+    fn decode(
+        &mut self,
+        input_image: EncodedImageRef<'_>,
+        render_time_ms: i64,
+    ) -> VideoCodecStatus {
+        VideoDecoder::decode(self, input_image, render_time_ms)
+    }
+
+    fn register_decode_complete_callback(
+        &mut self,
+        callback: Option<VideoDecoderDecodedImageCallbackPtr>,
+    ) -> VideoCodecStatus {
+        VideoDecoder::register_decode_complete_callback(self, callback)
+    }
+
+    fn release(&mut self) -> VideoCodecStatus {
+        VideoDecoder::release(self)
+    }
+
+    fn get_decoder_info(&mut self) -> VideoDecoderDecoderInfo {
+        VideoDecoder::get_decoder_info(self)
+    }
+}
+
 impl Drop for VideoDecoder {
     fn drop(&mut self) {
         unsafe { ffi::webrtc_VideoDecoder_unique_delete(self.raw_unique.as_ptr()) };
     }
 }
+
+unsafe impl Send for VideoDecoder {}
 
 /// webrtc::VideoDecoderFactory のラッパー。
 pub struct VideoDecoderFactory {
@@ -510,3 +560,5 @@ impl Drop for VideoDecoderFactory {
         unsafe { ffi::webrtc_VideoDecoderFactory_unique_delete(self.raw_unique.as_ptr()) };
     }
 }
+
+unsafe impl Send for VideoDecoderFactory {}

--- a/src/api/video_encoder.rs
+++ b/src/api/video_encoder.rs
@@ -1,6 +1,6 @@
 use super::video_codec_common::{
     EncodedImageRef, SdpVideoFormat, SdpVideoFormatRef, VideoCodecRef, VideoCodecStatus,
-    VideoCodecType, VideoFrame, VideoFrameRef, VideoFrameTypeVectorRef,
+    VideoCodecType, VideoFrameRef, VideoFrameTypeVectorRef,
 };
 use crate::{CxxString, EnvironmentRef, Result, ffi};
 use std::marker::PhantomData;
@@ -109,6 +109,10 @@ impl<'a> VideoEncoderSettingsRef<'a> {
         }
         Some(unsafe { ffi::webrtc_VideoEncoder_Settings_encoder_thread_limit(self.raw.as_ptr()) })
     }
+
+    pub(crate) fn as_ptr(&self) -> *mut ffi::webrtc_VideoEncoder_Settings {
+        self.raw.as_ptr()
+    }
 }
 
 unsafe impl<'a> Send for VideoEncoderSettingsRef<'a> {}
@@ -148,6 +152,10 @@ impl<'a> VideoEncoderRateControlParametersRef<'a> {
                 self.raw.as_ptr(),
             )
         }
+    }
+
+    pub(crate) fn as_ptr(&self) -> *mut ffi::webrtc_VideoEncoder_RateControlParameters {
+        self.raw.as_ptr()
     }
 }
 
@@ -1088,31 +1096,30 @@ impl VideoEncoder {
         std::mem::ManuallyDrop::new(self).raw_unique.as_ptr()
     }
 
-    pub fn init_encode(&mut self) -> VideoCodecStatus {
+    pub fn init_encode(
+        &mut self,
+        codec_settings: VideoCodecRef<'_>,
+        settings: VideoEncoderSettingsRef<'_>,
+    ) -> VideoCodecStatus {
         let value = unsafe {
             ffi::webrtc_VideoEncoder_InitEncode(
                 self.as_ptr(),
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
+                codec_settings.as_ptr(),
+                settings.as_ptr(),
             )
         };
         VideoCodecStatus::from_raw(value)
     }
 
-    pub fn encode(&mut self, frame: &VideoFrame) -> VideoCodecStatus {
-        self.encode_with_frame_types(frame, None)
-    }
-
-    pub fn encode_with_frame_types(
+    pub fn encode(
         &mut self,
-        frame: &VideoFrame,
+        frame: VideoFrameRef<'_>,
         frame_types: Option<VideoFrameTypeVectorRef<'_>>,
     ) -> VideoCodecStatus {
         let frame_types =
             frame_types.map_or(std::ptr::null_mut(), |frame_types| frame_types.as_ptr());
-        let value = unsafe {
-            ffi::webrtc_VideoEncoder_Encode(self.as_ptr(), frame.raw().as_ptr(), frame_types)
-        };
+        let value =
+            unsafe { ffi::webrtc_VideoEncoder_Encode(self.as_ptr(), frame.as_ptr(), frame_types) };
         VideoCodecStatus::from_raw(value)
     }
 
@@ -1127,8 +1134,13 @@ impl VideoEncoder {
         VideoCodecStatus::from_raw(value)
     }
 
-    pub fn set_rates(&mut self) {
-        unsafe { ffi::webrtc_VideoEncoder_SetRates(self.as_ptr(), std::ptr::null_mut()) };
+    pub fn set_rates(&mut self, parameters: VideoEncoderRateControlParametersRef<'_>) {
+        unsafe { ffi::webrtc_VideoEncoder_SetRates(self.as_ptr(), parameters.as_ptr()) };
+    }
+
+    pub fn release(&mut self) -> VideoCodecStatus {
+        let value = unsafe { ffi::webrtc_VideoEncoder_Release(self.as_ptr()) };
+        VideoCodecStatus::from_raw(value)
     }
 
     pub fn get_encoder_info(&self) -> VideoEncoderEncoderInfo {
@@ -1139,11 +1151,50 @@ impl VideoEncoder {
     }
 }
 
+impl VideoEncoderHandler for VideoEncoder {
+    fn init_encode(
+        &mut self,
+        codec_settings: VideoCodecRef<'_>,
+        settings: VideoEncoderSettingsRef<'_>,
+    ) -> VideoCodecStatus {
+        VideoEncoder::init_encode(self, codec_settings, settings)
+    }
+
+    fn encode(
+        &mut self,
+        frame: VideoFrameRef<'_>,
+        frame_types: Option<VideoFrameTypeVectorRef<'_>>,
+    ) -> VideoCodecStatus {
+        VideoEncoder::encode(self, frame, frame_types)
+    }
+
+    fn register_encode_complete_callback(
+        &mut self,
+        callback: Option<VideoEncoderEncodedImageCallbackRef<'_>>,
+    ) -> VideoCodecStatus {
+        VideoEncoder::register_encode_complete_callback(self, callback)
+    }
+
+    fn release(&mut self) -> VideoCodecStatus {
+        VideoEncoder::release(self)
+    }
+
+    fn set_rates(&mut self, parameters: VideoEncoderRateControlParametersRef<'_>) {
+        VideoEncoder::set_rates(self, parameters);
+    }
+
+    fn get_encoder_info(&mut self) -> VideoEncoderEncoderInfo {
+        VideoEncoder::get_encoder_info(self)
+    }
+}
+
 impl Drop for VideoEncoder {
     fn drop(&mut self) {
         unsafe { ffi::webrtc_VideoEncoder_unique_delete(self.raw_unique.as_ptr()) };
     }
 }
+
+unsafe impl Send for VideoEncoder {}
 
 /// webrtc::VideoEncoderFactory のラッパー。
 pub struct VideoEncoderFactory {
@@ -1220,3 +1271,5 @@ impl Drop for VideoEncoderFactory {
         unsafe { ffi::webrtc_VideoEncoderFactory_unique_delete(self.raw_unique.as_ptr()) };
     }
 }
+
+unsafe impl Send for VideoEncoderFactory {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,7 @@ pub enum Error {
     SdpParseError(SdpParseError),
     InvalidSdp,
     InvalidIceCandidate,
+    InvalidVideoCodecType(String),
     OutOfIndex(usize),
 }
 
@@ -42,6 +43,9 @@ impl fmt::Display for Error {
             }
             Error::InvalidSdp => f.write_str("不正な SDP です"),
             Error::InvalidIceCandidate => f.write_str("不正な ICE candidate です"),
+            Error::InvalidVideoCodecType(codec_type) => {
+                write!(f, "不正な VideoCodecType です: {}", codec_type)
+            }
             Error::OutOfIndex(index) => write!(f, "インデックス {} が範囲外です", index),
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -122,27 +122,36 @@ fn session_description_to_string() {
 
 #[test]
 fn sdp_video_format_with_parameters() {
-    let mut fmt = SdpVideoFormat::new("VP8");
-    {
-        let mut params = fmt.parameters_mut();
-        params.set("profile-id", "0");
-        params.set("level", "3.1");
-        assert_eq!(params.len(), 2);
+    let mut fmt = SdpVideoFormat::new_with_parameters(
+        "VP8",
+        &std::collections::HashMap::from([
+            (String::from("profile-id"), String::from("0")),
+            (String::from("level"), String::from("3.1")),
+        ]),
+        &[ScalabilityMode::L1T1, ScalabilityMode::L1T2],
+    );
+    let params = fmt.parameters_mut();
+    assert_eq!(params.len(), 2);
 
-        let mut found = std::collections::HashMap::new();
-        for (k, v) in params.iter() {
-            found.insert(k, v);
-        }
-        assert_eq!(found.get("profile-id").map(String::as_str), Some("0"));
-        assert_eq!(found.get("level").map(String::as_str), Some("3.1"));
+    let mut found = std::collections::HashMap::new();
+    for (k, v) in params.iter() {
+        found.insert(k, v);
     }
+    assert_eq!(found.get("profile-id").map(String::as_str), Some("0"));
+    assert_eq!(found.get("level").map(String::as_str), Some("3.1"));
+    assert_eq!(
+        fmt.scalability_modes(),
+        vec![ScalabilityMode::L1T1, ScalabilityMode::L1T2]
+    );
 
-    let mut other = SdpVideoFormat::new("VP8");
-    {
-        let mut params = other.parameters_mut();
-        params.set("profile-id", "0");
-        params.set("level", "3.1");
-    }
+    let other = SdpVideoFormat::new_with_parameters(
+        "VP8",
+        &std::collections::HashMap::from([
+            (String::from("profile-id"), String::from("0")),
+            (String::from("level"), String::from("3.1")),
+        ]),
+        &[ScalabilityMode::L1T1, ScalabilityMode::L1T2],
+    );
 
     assert!(fmt.is_equal(other.as_ref()));
 
@@ -162,6 +171,22 @@ fn sdp_video_format_with_parameters() {
     assert!(
         !has_packetization_mode,
         "clone への変更が元の SdpVideoFormat に影響しています"
+    );
+}
+
+#[test]
+fn sdp_video_format_new_has_empty_scalability_modes() {
+    let fmt = SdpVideoFormat::new("VP8");
+    assert!(fmt.scalability_modes().is_empty());
+}
+
+#[test]
+fn scalability_mode_round_trip() {
+    let mode = ScalabilityMode::L2T2;
+    assert_eq!(
+        mode.as_str()
+            .expect("ScalabilityMode の文字列化に失敗しました"),
+        "L2T2"
     );
 }
 
@@ -870,11 +895,11 @@ fn custom_video_encoder_factory_create_and_encode_calls_callbacks() {
     frame_types.push(VideoFrameType::Delta);
 
     assert_eq!(
-        encoder.encode_with_frame_types(&frame, Some(frame_types.as_ref())),
+        encoder.encode(frame.as_ref(), Some(frame_types.as_ref())),
         VideoCodecStatus::NoOutput
     );
     assert_eq!(
-        encoder.encode_with_frame_types(&frame, Some(frame_types.as_ref())),
+        encoder.encode(frame.as_ref(), Some(frame_types.as_ref())),
         VideoCodecStatus::Unknown(2)
     );
     assert!(
@@ -1162,7 +1187,10 @@ fn custom_video_encoder_register_and_encode_calls_encoded_image_and_codec_specif
 
     let buffer = I420Buffer::new(2, 2);
     let frame = VideoFrame::from_i420(&buffer, 123, 0);
-    assert_eq!(encoder.encode(&frame), VideoCodecStatus::Unknown(88));
+    assert_eq!(
+        encoder.encode(frame.as_ref(), None),
+        VideoCodecStatus::Unknown(88)
+    );
 
     assert!(state.register_called, "register が呼ばれていません");
     assert!(state.encode_called, "encode が呼ばれていません");
@@ -1222,9 +1250,16 @@ fn custom_video_decoder_factory_create_and_decode_calls_callbacks() {
     let mut decoder = factory
         .create(env.as_ref(), format.as_ref())
         .expect("custom decoder の作成に失敗しました");
+    let image = EncodedImage::new();
 
-    assert_eq!(decoder.decode(None, 456), VideoCodecStatus::NoOutput);
-    assert_eq!(decoder.decode(None, 456), VideoCodecStatus::Unknown(2));
+    assert_eq!(
+        decoder.decode(image.as_ref(), 456),
+        VideoCodecStatus::NoOutput
+    );
+    assert_eq!(
+        decoder.decode(image.as_ref(), 456),
+        VideoCodecStatus::Unknown(2)
+    );
     assert!(
         factory.create(env.as_ref(), format.as_ref()).is_none(),
         "2 回目の create は None を返す想定です"
@@ -1269,57 +1304,6 @@ fn video_decoder_handler_register_decode_complete_callback_accepts_none_and_some
     );
     assert!(handler.called_with_none);
     assert!(handler.called_with_some);
-}
-
-// set_rates callback の呼び出しを確認するテスト
-#[test]
-fn custom_video_encoder_init_encode_and_set_rates_callbacks_getters() {
-    struct BoolPtr(*mut bool);
-    unsafe impl Send for BoolPtr {}
-    impl BoolPtr {
-        fn set_true(&self) {
-            unsafe {
-                *self.0 = true;
-            }
-        }
-    }
-
-    struct TestVideoEncoderHandler {
-        set_rates_called_ptr: BoolPtr,
-    }
-    impl VideoEncoderHandler for TestVideoEncoderHandler {
-        fn init_encode(
-            &mut self,
-            codec: VideoCodecRef<'_>,
-            settings: VideoEncoderSettingsRef<'_>,
-        ) -> VideoCodecStatus {
-            assert_eq!(codec.codec_type(), VideoCodecType::Generic);
-            assert_eq!(codec.width(), 0);
-            assert_eq!(codec.height(), 0);
-            assert_eq!(settings.number_of_cores(), 1);
-            assert_eq!(settings.max_payload_size(), 1200);
-            assert!(!settings.loss_notification());
-            assert_eq!(settings.encoder_thread_limit(), None);
-            VideoCodecStatus::Unknown(123)
-        }
-
-        fn set_rates(&mut self, parameters: VideoEncoderRateControlParametersRef<'_>) {
-            assert_eq!(parameters.framerate_fps(), 30.0);
-            assert_eq!(parameters.target_bitrate_sum_bps(), 300_000);
-            assert_eq!(parameters.bitrate_sum_bps(), 250_000);
-            assert_eq!(parameters.bandwidth_allocation_bps(), 350_000);
-            self.set_rates_called_ptr.set_true();
-        }
-    }
-
-    let mut set_rates_called = false;
-    let mut encoder = VideoEncoder::new_with_handler(Box::new(TestVideoEncoderHandler {
-        set_rates_called_ptr: BoolPtr(&mut set_rates_called as *mut bool),
-    }));
-
-    assert_eq!(encoder.init_encode(), VideoCodecStatus::Unknown(123));
-    encoder.set_rates();
-    assert!(set_rates_called, "set_rates callback が呼ばれませんでした");
 }
 
 // implementation_name() が解放済みの値を返していることがあったので、その回帰テストを行う

--- a/webrtc/src/webrtc_c/api/dtls_transport_interface.cc
+++ b/webrtc/src/webrtc_c/api/dtls_transport_interface.cc
@@ -26,6 +26,7 @@ webrtc_DtlsTransportState webrtc_DtlsTransportInterface_state(
     return webrtc_DtlsTransportState_kClosed;
   }
   auto transport = reinterpret_cast<webrtc::DtlsTransportInterface*>(self);
-  return static_cast<webrtc_DtlsTransportState>(transport->Information().state());
+  return static_cast<webrtc_DtlsTransportState>(
+      transport->Information().state());
 }
 }

--- a/webrtc/src/webrtc_c/api/peer_connection_interface.cc
+++ b/webrtc/src/webrtc_c/api/peer_connection_interface.cc
@@ -134,10 +134,9 @@ class PeerConnectionObserverImpl : public webrtc::PeerConnectionObserver {
                            int error_code,
                            const std::string& error_text) override {
     if (observer_.OnIceCandidateError != nullptr) {
-      observer_.OnIceCandidateError(address.c_str(), address.size(), port,
-                                    url.c_str(), url.size(), error_code,
-                                    error_text.c_str(), error_text.size(),
-                                    user_data_);
+      observer_.OnIceCandidateError(
+          address.c_str(), address.size(), port, url.c_str(), url.size(),
+          error_code, error_text.c_str(), error_text.size(), user_data_);
     }
   }
   void OnTrack(webrtc::scoped_refptr<webrtc::RtpTransceiverInterface>
@@ -691,38 +690,46 @@ extern const int webrtc_PeerConnectionInterface_PeerConnectionState_kFailed =
 extern const int webrtc_PeerConnectionInterface_PeerConnectionState_kClosed =
     (int)webrtc::PeerConnectionInterface::PeerConnectionState::kClosed;
 extern const int
-    webrtc_PeerConnectionInterface_IceConnectionState_kIceConnectionNew =
-        (int)webrtc::PeerConnectionInterface::IceConnectionState::kIceConnectionNew;
+    webrtc_PeerConnectionInterface_IceConnectionState_kIceConnectionNew = (int)
+        webrtc::PeerConnectionInterface::IceConnectionState::kIceConnectionNew;
 extern const int
     webrtc_PeerConnectionInterface_IceConnectionState_kIceConnectionChecking =
-        (int)webrtc::PeerConnectionInterface::IceConnectionState::kIceConnectionChecking;
+        (int)webrtc::PeerConnectionInterface::IceConnectionState::
+            kIceConnectionChecking;
 extern const int
     webrtc_PeerConnectionInterface_IceConnectionState_kIceConnectionConnected =
-        (int)webrtc::PeerConnectionInterface::IceConnectionState::kIceConnectionConnected;
+        (int)webrtc::PeerConnectionInterface::IceConnectionState::
+            kIceConnectionConnected;
 extern const int
     webrtc_PeerConnectionInterface_IceConnectionState_kIceConnectionCompleted =
-        (int)webrtc::PeerConnectionInterface::IceConnectionState::kIceConnectionCompleted;
+        (int)webrtc::PeerConnectionInterface::IceConnectionState::
+            kIceConnectionCompleted;
 extern const int
     webrtc_PeerConnectionInterface_IceConnectionState_kIceConnectionFailed =
-        (int)webrtc::PeerConnectionInterface::IceConnectionState::kIceConnectionFailed;
+        (int)webrtc::PeerConnectionInterface::IceConnectionState::
+            kIceConnectionFailed;
 extern const int
     webrtc_PeerConnectionInterface_IceConnectionState_kIceConnectionDisconnected =
-        (int)webrtc::PeerConnectionInterface::IceConnectionState::kIceConnectionDisconnected;
+        (int)webrtc::PeerConnectionInterface::IceConnectionState::
+            kIceConnectionDisconnected;
 extern const int
     webrtc_PeerConnectionInterface_IceConnectionState_kIceConnectionClosed =
-        (int)webrtc::PeerConnectionInterface::IceConnectionState::kIceConnectionClosed;
+        (int)webrtc::PeerConnectionInterface::IceConnectionState::
+            kIceConnectionClosed;
 extern const int
-    webrtc_PeerConnectionInterface_IceConnectionState_kIceConnectionMax =
-        (int)webrtc::PeerConnectionInterface::IceConnectionState::kIceConnectionMax;
+    webrtc_PeerConnectionInterface_IceConnectionState_kIceConnectionMax = (int)
+        webrtc::PeerConnectionInterface::IceConnectionState::kIceConnectionMax;
 extern const int
-    webrtc_PeerConnectionInterface_IceGatheringState_kIceGatheringNew =
-        (int)webrtc::PeerConnectionInterface::IceGatheringState::kIceGatheringNew;
+    webrtc_PeerConnectionInterface_IceGatheringState_kIceGatheringNew = (int)
+        webrtc::PeerConnectionInterface::IceGatheringState::kIceGatheringNew;
 extern const int
     webrtc_PeerConnectionInterface_IceGatheringState_kIceGatheringGathering =
-        (int)webrtc::PeerConnectionInterface::IceGatheringState::kIceGatheringGathering;
+        (int)webrtc::PeerConnectionInterface::IceGatheringState::
+            kIceGatheringGathering;
 extern const int
     webrtc_PeerConnectionInterface_IceGatheringState_kIceGatheringComplete =
-        (int)webrtc::PeerConnectionInterface::IceGatheringState::kIceGatheringComplete;
+        (int)webrtc::PeerConnectionInterface::IceGatheringState::
+            kIceGatheringComplete;
 }
 
 // -------------------------

--- a/webrtc/src/webrtc_c/api/peer_connection_interface.h
+++ b/webrtc/src/webrtc_c/api/peer_connection_interface.h
@@ -144,7 +144,8 @@ extern const int
 extern const int webrtc_PeerConnectionInterface_PeerConnectionState_kFailed;
 extern const int webrtc_PeerConnectionInterface_PeerConnectionState_kClosed;
 typedef int webrtc_PeerConnectionInterface_IceConnectionState;
-extern const int webrtc_PeerConnectionInterface_IceConnectionState_kIceConnectionNew;
+extern const int
+    webrtc_PeerConnectionInterface_IceConnectionState_kIceConnectionNew;
 extern const int
     webrtc_PeerConnectionInterface_IceConnectionState_kIceConnectionChecking;
 extern const int
@@ -160,7 +161,8 @@ extern const int
 extern const int
     webrtc_PeerConnectionInterface_IceConnectionState_kIceConnectionMax;
 typedef int webrtc_PeerConnectionInterface_IceGatheringState;
-extern const int webrtc_PeerConnectionInterface_IceGatheringState_kIceGatheringNew;
+extern const int
+    webrtc_PeerConnectionInterface_IceGatheringState_kIceGatheringNew;
 extern const int
     webrtc_PeerConnectionInterface_IceGatheringState_kIceGatheringGathering;
 extern const int

--- a/webrtc/src/webrtc_c/api/video_codecs/sdp_video_format.cc
+++ b/webrtc/src/webrtc_c/api/video_codecs/sdp_video_format.cc
@@ -1,34 +1,75 @@
 #include "sdp_video_format.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <map>
 #include <memory>
 #include <string>
 
+// Abseil
+#include <absl/container/inlined_vector.h>
+
 // WebRTC
+#include <api/video_codecs/scalability_mode.h>
 #include <api/video_codecs/sdp_video_format.h>
 
 #include "../../common.impl.h"
 #include "../../std.h"
+
+namespace {}  // namespace
 
 extern "C" {
 WEBRTC_DEFINE_UNIQUE(webrtc_SdpVideoFormat, webrtc::SdpVideoFormat);
 WEBRTC_DEFINE_VECTOR_NO_DEFAULT_CTOR(webrtc_SdpVideoFormat,
                                      webrtc::SdpVideoFormat);
 
+struct std_string_unique* webrtc_ScalabilityModeToString(
+    enum webrtc_ScalabilityMode mode) {
+  if (static_cast<size_t>(mode) >= webrtc::kScalabilityModeCount) {
+    return nullptr;
+  }
+  auto cpp_mode = static_cast<webrtc::ScalabilityMode>(mode);
+  auto mode_string =
+      std::make_unique<std::string>(webrtc::ScalabilityModeToString(cpp_mode));
+  return reinterpret_cast<struct std_string_unique*>(mode_string.release());
+}
+
 struct webrtc_SdpVideoFormat_unique* webrtc_SdpVideoFormat_new(
     const char* name,
-    size_t name_len,
-    struct std_map_string_string* parameters) {
+    size_t name_len) {
   std::string n = name != nullptr ? std::string(name, name_len) : std::string();
-  if (parameters != nullptr) {
-    auto params =
-        reinterpret_cast<std::map<std::string, std::string>*>(parameters);
-    auto fmt = std::make_unique<webrtc::SdpVideoFormat>(n, *params);
-    return reinterpret_cast<struct webrtc_SdpVideoFormat_unique*>(
-        fmt.release());
-  }
   auto fmt = std::make_unique<webrtc::SdpVideoFormat>(n);
+  return reinterpret_cast<struct webrtc_SdpVideoFormat_unique*>(fmt.release());
+}
+
+struct webrtc_SdpVideoFormat_unique* webrtc_SdpVideoFormat_new_with_parameters(
+    const char* name,
+    size_t name_len,
+    struct std_map_string_string* parameters,
+    const enum webrtc_ScalabilityMode* scalability_modes,
+    size_t scalability_modes_len) {
+  std::string n = name != nullptr ? std::string(name, name_len) : std::string();
+  std::map<std::string, std::string> params;
+  if (parameters != nullptr) {
+    auto parameter_map =
+        reinterpret_cast<std::map<std::string, std::string>*>(parameters);
+    params = *parameter_map;
+  }
+
+  absl::InlinedVector<webrtc::ScalabilityMode, webrtc::kScalabilityModeCount>
+      modes;
+  modes.reserve(scalability_modes_len);
+  if (scalability_modes != nullptr) {
+    for (size_t i = 0; i < scalability_modes_len; ++i) {
+      if (static_cast<size_t>(scalability_modes[i]) <
+          webrtc::kScalabilityModeCount) {
+        modes.push_back(
+            static_cast<webrtc::ScalabilityMode>(scalability_modes[i]));
+      }
+    }
+  }
+
+  auto fmt = std::make_unique<webrtc::SdpVideoFormat>(n, params, modes);
   return reinterpret_cast<struct webrtc_SdpVideoFormat_unique*>(fmt.release());
 }
 struct webrtc_SdpVideoFormat_unique* webrtc_SdpVideoFormat_copy(
@@ -50,6 +91,29 @@ struct std_map_string_string* webrtc_SdpVideoFormat_get_parameters(
     struct webrtc_SdpVideoFormat* self) {
   auto fmt = reinterpret_cast<webrtc::SdpVideoFormat*>(self);
   return reinterpret_cast<struct std_map_string_string*>(&fmt->parameters);
+}
+size_t webrtc_SdpVideoFormat_get_scalability_modes_size(
+    struct webrtc_SdpVideoFormat* self) {
+  auto fmt = reinterpret_cast<webrtc::SdpVideoFormat*>(self);
+  if (fmt == nullptr) {
+    return 0;
+  }
+  return fmt->scalability_modes.size();
+}
+size_t webrtc_SdpVideoFormat_copy_scalability_modes(
+    struct webrtc_SdpVideoFormat* self,
+    enum webrtc_ScalabilityMode* out_modes,
+    size_t out_modes_len) {
+  auto fmt = reinterpret_cast<webrtc::SdpVideoFormat*>(self);
+  if (fmt == nullptr || out_modes == nullptr) {
+    return 0;
+  }
+  const size_t copied = std::min(out_modes_len, fmt->scalability_modes.size());
+  for (size_t i = 0; i < copied; ++i) {
+    out_modes[i] =
+        static_cast<enum webrtc_ScalabilityMode>(fmt->scalability_modes[i]);
+  }
+  return copied;
 }
 int webrtc_SdpVideoFormat_is_equal(struct webrtc_SdpVideoFormat* lhs,
                                    struct webrtc_SdpVideoFormat* rhs) {

--- a/webrtc/src/webrtc_c/api/video_codecs/sdp_video_format.cc
+++ b/webrtc/src/webrtc_c/api/video_codecs/sdp_video_format.cc
@@ -16,21 +16,84 @@
 #include "../../common.impl.h"
 #include "../../std.h"
 
-namespace {}  // namespace
-
 extern "C" {
+const int webrtc_ScalabilityMode_L1T1 =
+    static_cast<int>(webrtc::ScalabilityMode::kL1T1);
+const int webrtc_ScalabilityMode_L1T2 =
+    static_cast<int>(webrtc::ScalabilityMode::kL1T2);
+const int webrtc_ScalabilityMode_L1T3 =
+    static_cast<int>(webrtc::ScalabilityMode::kL1T3);
+const int webrtc_ScalabilityMode_L2T1 =
+    static_cast<int>(webrtc::ScalabilityMode::kL2T1);
+const int webrtc_ScalabilityMode_L2T1h =
+    static_cast<int>(webrtc::ScalabilityMode::kL2T1h);
+const int webrtc_ScalabilityMode_L2T1_KEY =
+    static_cast<int>(webrtc::ScalabilityMode::kL2T1_KEY);
+const int webrtc_ScalabilityMode_L2T2 =
+    static_cast<int>(webrtc::ScalabilityMode::kL2T2);
+const int webrtc_ScalabilityMode_L2T2h =
+    static_cast<int>(webrtc::ScalabilityMode::kL2T2h);
+const int webrtc_ScalabilityMode_L2T2_KEY =
+    static_cast<int>(webrtc::ScalabilityMode::kL2T2_KEY);
+const int webrtc_ScalabilityMode_L2T2_KEY_SHIFT =
+    static_cast<int>(webrtc::ScalabilityMode::kL2T2_KEY_SHIFT);
+const int webrtc_ScalabilityMode_L2T3 =
+    static_cast<int>(webrtc::ScalabilityMode::kL2T3);
+const int webrtc_ScalabilityMode_L2T3h =
+    static_cast<int>(webrtc::ScalabilityMode::kL2T3h);
+const int webrtc_ScalabilityMode_L2T3_KEY =
+    static_cast<int>(webrtc::ScalabilityMode::kL2T3_KEY);
+const int webrtc_ScalabilityMode_L3T1 =
+    static_cast<int>(webrtc::ScalabilityMode::kL3T1);
+const int webrtc_ScalabilityMode_L3T1h =
+    static_cast<int>(webrtc::ScalabilityMode::kL3T1h);
+const int webrtc_ScalabilityMode_L3T1_KEY =
+    static_cast<int>(webrtc::ScalabilityMode::kL3T1_KEY);
+const int webrtc_ScalabilityMode_L3T2 =
+    static_cast<int>(webrtc::ScalabilityMode::kL3T2);
+const int webrtc_ScalabilityMode_L3T2h =
+    static_cast<int>(webrtc::ScalabilityMode::kL3T2h);
+const int webrtc_ScalabilityMode_L3T2_KEY =
+    static_cast<int>(webrtc::ScalabilityMode::kL3T2_KEY);
+const int webrtc_ScalabilityMode_L3T3 =
+    static_cast<int>(webrtc::ScalabilityMode::kL3T3);
+const int webrtc_ScalabilityMode_L3T3h =
+    static_cast<int>(webrtc::ScalabilityMode::kL3T3h);
+const int webrtc_ScalabilityMode_L3T3_KEY =
+    static_cast<int>(webrtc::ScalabilityMode::kL3T3_KEY);
+const int webrtc_ScalabilityMode_S2T1 =
+    static_cast<int>(webrtc::ScalabilityMode::kS2T1);
+const int webrtc_ScalabilityMode_S2T1h =
+    static_cast<int>(webrtc::ScalabilityMode::kS2T1h);
+const int webrtc_ScalabilityMode_S2T2 =
+    static_cast<int>(webrtc::ScalabilityMode::kS2T2);
+const int webrtc_ScalabilityMode_S2T2h =
+    static_cast<int>(webrtc::ScalabilityMode::kS2T2h);
+const int webrtc_ScalabilityMode_S2T3 =
+    static_cast<int>(webrtc::ScalabilityMode::kS2T3);
+const int webrtc_ScalabilityMode_S2T3h =
+    static_cast<int>(webrtc::ScalabilityMode::kS2T3h);
+const int webrtc_ScalabilityMode_S3T1 =
+    static_cast<int>(webrtc::ScalabilityMode::kS3T1);
+const int webrtc_ScalabilityMode_S3T1h =
+    static_cast<int>(webrtc::ScalabilityMode::kS3T1h);
+const int webrtc_ScalabilityMode_S3T2 =
+    static_cast<int>(webrtc::ScalabilityMode::kS3T2);
+const int webrtc_ScalabilityMode_S3T2h =
+    static_cast<int>(webrtc::ScalabilityMode::kS3T2h);
+const int webrtc_ScalabilityMode_S3T3 =
+    static_cast<int>(webrtc::ScalabilityMode::kS3T3);
+const int webrtc_ScalabilityMode_S3T3h =
+    static_cast<int>(webrtc::ScalabilityMode::kS3T3h);
+
 WEBRTC_DEFINE_UNIQUE(webrtc_SdpVideoFormat, webrtc::SdpVideoFormat);
 WEBRTC_DEFINE_VECTOR_NO_DEFAULT_CTOR(webrtc_SdpVideoFormat,
                                      webrtc::SdpVideoFormat);
 
-struct std_string_unique* webrtc_ScalabilityModeToString(
-    enum webrtc_ScalabilityMode mode) {
-  if (static_cast<size_t>(mode) >= webrtc::kScalabilityModeCount) {
-    return nullptr;
-  }
-  auto cpp_mode = static_cast<webrtc::ScalabilityMode>(mode);
-  auto mode_string =
-      std::make_unique<std::string>(webrtc::ScalabilityModeToString(cpp_mode));
+struct std_string_unique* webrtc_ScalabilityModeToString(int mode) {
+  auto mode_string = std::make_unique<std::string>(
+      webrtc::ScalabilityModeToString(
+          static_cast<webrtc::ScalabilityMode>(mode)));
   return reinterpret_cast<struct std_string_unique*>(mode_string.release());
 }
 
@@ -46,7 +109,7 @@ struct webrtc_SdpVideoFormat_unique* webrtc_SdpVideoFormat_new_with_parameters(
     const char* name,
     size_t name_len,
     struct std_map_string_string* parameters,
-    const enum webrtc_ScalabilityMode* scalability_modes,
+    const int* scalability_modes,
     size_t scalability_modes_len) {
   std::string n = name != nullptr ? std::string(name, name_len) : std::string();
   std::map<std::string, std::string> params;
@@ -61,17 +124,15 @@ struct webrtc_SdpVideoFormat_unique* webrtc_SdpVideoFormat_new_with_parameters(
   modes.reserve(scalability_modes_len);
   if (scalability_modes != nullptr) {
     for (size_t i = 0; i < scalability_modes_len; ++i) {
-      if (static_cast<size_t>(scalability_modes[i]) <
-          webrtc::kScalabilityModeCount) {
-        modes.push_back(
-            static_cast<webrtc::ScalabilityMode>(scalability_modes[i]));
-      }
+      modes.push_back(
+          static_cast<webrtc::ScalabilityMode>(scalability_modes[i]));
     }
   }
 
   auto fmt = std::make_unique<webrtc::SdpVideoFormat>(n, params, modes);
   return reinterpret_cast<struct webrtc_SdpVideoFormat_unique*>(fmt.release());
 }
+
 struct webrtc_SdpVideoFormat_unique* webrtc_SdpVideoFormat_copy(
     struct webrtc_SdpVideoFormat* self) {
   auto fmt = reinterpret_cast<webrtc::SdpVideoFormat*>(self);
@@ -82,16 +143,19 @@ struct webrtc_SdpVideoFormat_unique* webrtc_SdpVideoFormat_copy(
   return reinterpret_cast<struct webrtc_SdpVideoFormat_unique*>(
       copied.release());
 }
+
 struct std_string* webrtc_SdpVideoFormat_get_name(
     struct webrtc_SdpVideoFormat* self) {
   auto fmt = reinterpret_cast<webrtc::SdpVideoFormat*>(self);
   return reinterpret_cast<struct std_string*>(&fmt->name);
 }
+
 struct std_map_string_string* webrtc_SdpVideoFormat_get_parameters(
     struct webrtc_SdpVideoFormat* self) {
   auto fmt = reinterpret_cast<webrtc::SdpVideoFormat*>(self);
   return reinterpret_cast<struct std_map_string_string*>(&fmt->parameters);
 }
+
 size_t webrtc_SdpVideoFormat_get_scalability_modes_size(
     struct webrtc_SdpVideoFormat* self) {
   auto fmt = reinterpret_cast<webrtc::SdpVideoFormat*>(self);
@@ -100,9 +164,10 @@ size_t webrtc_SdpVideoFormat_get_scalability_modes_size(
   }
   return fmt->scalability_modes.size();
 }
+
 size_t webrtc_SdpVideoFormat_copy_scalability_modes(
     struct webrtc_SdpVideoFormat* self,
-    enum webrtc_ScalabilityMode* out_modes,
+    int* out_modes,
     size_t out_modes_len) {
   auto fmt = reinterpret_cast<webrtc::SdpVideoFormat*>(self);
   if (fmt == nullptr || out_modes == nullptr) {
@@ -110,11 +175,11 @@ size_t webrtc_SdpVideoFormat_copy_scalability_modes(
   }
   const size_t copied = std::min(out_modes_len, fmt->scalability_modes.size());
   for (size_t i = 0; i < copied; ++i) {
-    out_modes[i] =
-        static_cast<enum webrtc_ScalabilityMode>(fmt->scalability_modes[i]);
+    out_modes[i] = static_cast<int>(fmt->scalability_modes[i]);
   }
   return copied;
 }
+
 int webrtc_SdpVideoFormat_is_equal(struct webrtc_SdpVideoFormat* lhs,
                                    struct webrtc_SdpVideoFormat* rhs) {
   auto a = reinterpret_cast<webrtc::SdpVideoFormat*>(lhs);

--- a/webrtc/src/webrtc_c/api/video_codecs/sdp_video_format.h
+++ b/webrtc/src/webrtc_c/api/video_codecs/sdp_video_format.h
@@ -13,18 +13,67 @@ extern "C" {
 // webrtc::SdpVideoFormat
 // -------------------------
 
+enum webrtc_ScalabilityMode {
+  webrtc_ScalabilityMode_L1T1 = 0,
+  webrtc_ScalabilityMode_L1T2,
+  webrtc_ScalabilityMode_L1T3,
+  webrtc_ScalabilityMode_L2T1,
+  webrtc_ScalabilityMode_L2T1h,
+  webrtc_ScalabilityMode_L2T1_KEY,
+  webrtc_ScalabilityMode_L2T2,
+  webrtc_ScalabilityMode_L2T2h,
+  webrtc_ScalabilityMode_L2T2_KEY,
+  webrtc_ScalabilityMode_L2T2_KEY_SHIFT,
+  webrtc_ScalabilityMode_L2T3,
+  webrtc_ScalabilityMode_L2T3h,
+  webrtc_ScalabilityMode_L2T3_KEY,
+  webrtc_ScalabilityMode_L3T1,
+  webrtc_ScalabilityMode_L3T1h,
+  webrtc_ScalabilityMode_L3T1_KEY,
+  webrtc_ScalabilityMode_L3T2,
+  webrtc_ScalabilityMode_L3T2h,
+  webrtc_ScalabilityMode_L3T2_KEY,
+  webrtc_ScalabilityMode_L3T3,
+  webrtc_ScalabilityMode_L3T3h,
+  webrtc_ScalabilityMode_L3T3_KEY,
+  webrtc_ScalabilityMode_S2T1,
+  webrtc_ScalabilityMode_S2T1h,
+  webrtc_ScalabilityMode_S2T2,
+  webrtc_ScalabilityMode_S2T2h,
+  webrtc_ScalabilityMode_S2T3,
+  webrtc_ScalabilityMode_S2T3h,
+  webrtc_ScalabilityMode_S3T1,
+  webrtc_ScalabilityMode_S3T1h,
+  webrtc_ScalabilityMode_S3T2,
+  webrtc_ScalabilityMode_S3T2h,
+  webrtc_ScalabilityMode_S3T3,
+  webrtc_ScalabilityMode_S3T3h,
+};
+struct std_string_unique* webrtc_ScalabilityModeToString(
+    enum webrtc_ScalabilityMode mode);
+
 WEBRTC_DECLARE_UNIQUE(webrtc_SdpVideoFormat);
 WEBRTC_DECLARE_VECTOR_NO_DEFAULT_CTOR(webrtc_SdpVideoFormat);
-struct webrtc_SdpVideoFormat_unique* webrtc_SdpVideoFormat_new(
+struct webrtc_SdpVideoFormat_unique* webrtc_SdpVideoFormat_new(const char* name,
+                                                               size_t name_len);
+struct webrtc_SdpVideoFormat_unique* webrtc_SdpVideoFormat_new_with_parameters(
     const char* name,
     size_t name_len,
-    struct std_map_string_string* parameters);
+    struct std_map_string_string* parameters,
+    const enum webrtc_ScalabilityMode* scalability_modes,
+    size_t scalability_modes_len);
 struct webrtc_SdpVideoFormat_unique* webrtc_SdpVideoFormat_copy(
     struct webrtc_SdpVideoFormat* self);
 struct std_string* webrtc_SdpVideoFormat_get_name(
     struct webrtc_SdpVideoFormat* self);
 struct std_map_string_string* webrtc_SdpVideoFormat_get_parameters(
     struct webrtc_SdpVideoFormat* self);
+size_t webrtc_SdpVideoFormat_get_scalability_modes_size(
+    struct webrtc_SdpVideoFormat* self);
+size_t webrtc_SdpVideoFormat_copy_scalability_modes(
+    struct webrtc_SdpVideoFormat* self,
+    enum webrtc_ScalabilityMode* out_modes,
+    size_t out_modes_len);
 int webrtc_SdpVideoFormat_is_equal(struct webrtc_SdpVideoFormat* lhs,
                                    struct webrtc_SdpVideoFormat* rhs);
 

--- a/webrtc/src/webrtc_c/api/video_codecs/sdp_video_format.h
+++ b/webrtc/src/webrtc_c/api/video_codecs/sdp_video_format.h
@@ -13,44 +13,42 @@ extern "C" {
 // webrtc::SdpVideoFormat
 // -------------------------
 
-enum webrtc_ScalabilityMode {
-  webrtc_ScalabilityMode_L1T1 = 0,
-  webrtc_ScalabilityMode_L1T2,
-  webrtc_ScalabilityMode_L1T3,
-  webrtc_ScalabilityMode_L2T1,
-  webrtc_ScalabilityMode_L2T1h,
-  webrtc_ScalabilityMode_L2T1_KEY,
-  webrtc_ScalabilityMode_L2T2,
-  webrtc_ScalabilityMode_L2T2h,
-  webrtc_ScalabilityMode_L2T2_KEY,
-  webrtc_ScalabilityMode_L2T2_KEY_SHIFT,
-  webrtc_ScalabilityMode_L2T3,
-  webrtc_ScalabilityMode_L2T3h,
-  webrtc_ScalabilityMode_L2T3_KEY,
-  webrtc_ScalabilityMode_L3T1,
-  webrtc_ScalabilityMode_L3T1h,
-  webrtc_ScalabilityMode_L3T1_KEY,
-  webrtc_ScalabilityMode_L3T2,
-  webrtc_ScalabilityMode_L3T2h,
-  webrtc_ScalabilityMode_L3T2_KEY,
-  webrtc_ScalabilityMode_L3T3,
-  webrtc_ScalabilityMode_L3T3h,
-  webrtc_ScalabilityMode_L3T3_KEY,
-  webrtc_ScalabilityMode_S2T1,
-  webrtc_ScalabilityMode_S2T1h,
-  webrtc_ScalabilityMode_S2T2,
-  webrtc_ScalabilityMode_S2T2h,
-  webrtc_ScalabilityMode_S2T3,
-  webrtc_ScalabilityMode_S2T3h,
-  webrtc_ScalabilityMode_S3T1,
-  webrtc_ScalabilityMode_S3T1h,
-  webrtc_ScalabilityMode_S3T2,
-  webrtc_ScalabilityMode_S3T2h,
-  webrtc_ScalabilityMode_S3T3,
-  webrtc_ScalabilityMode_S3T3h,
-};
+extern const int webrtc_ScalabilityMode_L1T1;
+extern const int webrtc_ScalabilityMode_L1T2;
+extern const int webrtc_ScalabilityMode_L1T3;
+extern const int webrtc_ScalabilityMode_L2T1;
+extern const int webrtc_ScalabilityMode_L2T1h;
+extern const int webrtc_ScalabilityMode_L2T1_KEY;
+extern const int webrtc_ScalabilityMode_L2T2;
+extern const int webrtc_ScalabilityMode_L2T2h;
+extern const int webrtc_ScalabilityMode_L2T2_KEY;
+extern const int webrtc_ScalabilityMode_L2T2_KEY_SHIFT;
+extern const int webrtc_ScalabilityMode_L2T3;
+extern const int webrtc_ScalabilityMode_L2T3h;
+extern const int webrtc_ScalabilityMode_L2T3_KEY;
+extern const int webrtc_ScalabilityMode_L3T1;
+extern const int webrtc_ScalabilityMode_L3T1h;
+extern const int webrtc_ScalabilityMode_L3T1_KEY;
+extern const int webrtc_ScalabilityMode_L3T2;
+extern const int webrtc_ScalabilityMode_L3T2h;
+extern const int webrtc_ScalabilityMode_L3T2_KEY;
+extern const int webrtc_ScalabilityMode_L3T3;
+extern const int webrtc_ScalabilityMode_L3T3h;
+extern const int webrtc_ScalabilityMode_L3T3_KEY;
+extern const int webrtc_ScalabilityMode_S2T1;
+extern const int webrtc_ScalabilityMode_S2T1h;
+extern const int webrtc_ScalabilityMode_S2T2;
+extern const int webrtc_ScalabilityMode_S2T2h;
+extern const int webrtc_ScalabilityMode_S2T3;
+extern const int webrtc_ScalabilityMode_S2T3h;
+extern const int webrtc_ScalabilityMode_S3T1;
+extern const int webrtc_ScalabilityMode_S3T1h;
+extern const int webrtc_ScalabilityMode_S3T2;
+extern const int webrtc_ScalabilityMode_S3T2h;
+extern const int webrtc_ScalabilityMode_S3T3;
+extern const int webrtc_ScalabilityMode_S3T3h;
 struct std_string_unique* webrtc_ScalabilityModeToString(
-    enum webrtc_ScalabilityMode mode);
+    int mode);
 
 WEBRTC_DECLARE_UNIQUE(webrtc_SdpVideoFormat);
 WEBRTC_DECLARE_VECTOR_NO_DEFAULT_CTOR(webrtc_SdpVideoFormat);
@@ -60,7 +58,7 @@ struct webrtc_SdpVideoFormat_unique* webrtc_SdpVideoFormat_new_with_parameters(
     const char* name,
     size_t name_len,
     struct std_map_string_string* parameters,
-    const enum webrtc_ScalabilityMode* scalability_modes,
+    const int* scalability_modes,
     size_t scalability_modes_len);
 struct webrtc_SdpVideoFormat_unique* webrtc_SdpVideoFormat_copy(
     struct webrtc_SdpVideoFormat* self);
@@ -72,7 +70,7 @@ size_t webrtc_SdpVideoFormat_get_scalability_modes_size(
     struct webrtc_SdpVideoFormat* self);
 size_t webrtc_SdpVideoFormat_copy_scalability_modes(
     struct webrtc_SdpVideoFormat* self,
-    enum webrtc_ScalabilityMode* out_modes,
+    int* out_modes,
     size_t out_modes_len);
 int webrtc_SdpVideoFormat_is_equal(struct webrtc_SdpVideoFormat* lhs,
                                    struct webrtc_SdpVideoFormat* rhs);

--- a/webrtc/src/webrtc_c/api/video_codecs/video_decoder.cc
+++ b/webrtc/src/webrtc_c/api/video_codecs/video_decoder.cc
@@ -14,6 +14,7 @@
 
 #include "../../common.impl.h"
 #include "../../std.h"
+#include "../video/video_frame.h"
 
 namespace {
 
@@ -228,6 +229,26 @@ int32_t webrtc_VideoDecoder_Decode(struct webrtc_VideoDecoder* self,
   }
   webrtc::EncodedImage default_input_image;
   return decoder->Decode(default_input_image, render_time_ms);
+}
+
+int32_t webrtc_VideoDecoder_RegisterDecodeCompleteCallback(
+    struct webrtc_VideoDecoder* self,
+    struct webrtc_VideoDecoder_DecodedImageCallback* callback) {
+  if (self == nullptr) {
+    return -1;
+  }
+  auto decoder = reinterpret_cast<webrtc::VideoDecoder*>(self);
+  auto decoded_image_callback =
+      reinterpret_cast<webrtc::DecodedImageCallback*>(callback);
+  return decoder->RegisterDecodeCompleteCallback(decoded_image_callback);
+}
+
+int32_t webrtc_VideoDecoder_Release(struct webrtc_VideoDecoder* self) {
+  if (self == nullptr) {
+    return -1;
+  }
+  auto decoder = reinterpret_cast<webrtc::VideoDecoder*>(self);
+  return decoder->Release();
 }
 
 struct webrtc_VideoDecoder_DecoderInfo_unique*

--- a/webrtc/src/webrtc_c/api/video_codecs/video_decoder.h
+++ b/webrtc/src/webrtc_c/api/video_codecs/video_decoder.h
@@ -76,6 +76,10 @@ int webrtc_VideoDecoder_Configure(
 int32_t webrtc_VideoDecoder_Decode(struct webrtc_VideoDecoder* self,
                                    struct webrtc_EncodedImage* input_image,
                                    int64_t render_time_ms);
+int32_t webrtc_VideoDecoder_RegisterDecodeCompleteCallback(
+    struct webrtc_VideoDecoder* self,
+    struct webrtc_VideoDecoder_DecodedImageCallback* callback);
+int32_t webrtc_VideoDecoder_Release(struct webrtc_VideoDecoder* self);
 struct webrtc_VideoDecoder_DecoderInfo_unique*
 webrtc_VideoDecoder_GetDecoderInfo(struct webrtc_VideoDecoder* self);
 

--- a/webrtc/src/webrtc_c/api/video_codecs/video_encoder.cc
+++ b/webrtc/src/webrtc_c/api/video_codecs/video_encoder.cc
@@ -379,6 +379,14 @@ int32_t webrtc_VideoEncoder_RegisterEncodeCompleteCallback(
   return encoder->RegisterEncodeCompleteCallback(encoded_image_callback);
 }
 
+int32_t webrtc_VideoEncoder_Release(struct webrtc_VideoEncoder* self) {
+  if (self == nullptr) {
+    return -1;
+  }
+  auto encoder = reinterpret_cast<webrtc::VideoEncoder*>(self);
+  return encoder->Release();
+}
+
 void webrtc_VideoEncoder_SetRates(
     struct webrtc_VideoEncoder* self,
     struct webrtc_VideoEncoder_RateControlParameters* parameters) {

--- a/webrtc/src/webrtc_c/api/video_codecs/video_encoder.h
+++ b/webrtc/src/webrtc_c/api/video_codecs/video_encoder.h
@@ -122,6 +122,7 @@ int32_t webrtc_VideoEncoder_Encode(
 int32_t webrtc_VideoEncoder_RegisterEncodeCompleteCallback(
     struct webrtc_VideoEncoder* self,
     struct webrtc_VideoEncoder_EncodedImageCallback* callback);
+int32_t webrtc_VideoEncoder_Release(struct webrtc_VideoEncoder* self);
 void webrtc_VideoEncoder_SetRates(
     struct webrtc_VideoEncoder* self,
     struct webrtc_VideoEncoder_RateControlParameters* parameters);


### PR DESCRIPTION
- `VideoEncoder` / `VideoDecoder` の引数を調整して を `VideoEncoderHandler` / `VideoDecoderHandler` の実装として扱えるようにする
- `SdpVideoFormat` の scalability_modes や parameters を扱えるようにする
- `ScalabilityMode` を libwebrtc から移植する
- `VideoCodecType` を文字列にしたりパース可能にする