### PR TITLE
DtlsTransport / DtlsTransportObserver / DtlsTransportState を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 ## develop
 
+- [ADD] `DtlsTransport` / `DtlsTransportObserver` / `DtlsTransportState` を追加する
+  - @voluntas
+- [ADD] `PeerConnection::lookup_dtls_transport_by_mid` を追加する
+  - @voluntas
 - [UPDATE] libwebrtc m146 (m146.7680.3.1) に上げる
   - @voluntas
 - [ADD] トラックの有効/無効を制御する `MediaStreamTrack::enabled` / `MediaStreamTrack::set_enabled` を追加する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - [ADD] `DtlsTransport` / `DtlsTransportObserver` / `DtlsTransportState` を追加する
   - @voluntas
 - [ADD] `PeerConnection::lookup_dtls_transport_by_mid` を追加する
+  - `DtlsTransport` のインスタンスを取得するために必要
   - @voluntas
 - [UPDATE] libwebrtc m146 (m146.7680.3.1) に上げる
   - @voluntas

--- a/src/api/dtls_transport.rs
+++ b/src/api/dtls_transport.rs
@@ -1,0 +1,155 @@
+use crate::ref_count::DtlsTransportHandle;
+use crate::{ScopedRef, ffi};
+use std::os::raw::c_void;
+use std::ptr::NonNull;
+
+/// DtlsTransport の状態。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DtlsTransportState {
+    New,
+    Connecting,
+    Connected,
+    Closed,
+    Failed,
+    Unknown(i32),
+}
+
+impl DtlsTransportState {
+    pub fn from_int(value: i32) -> Self {
+        unsafe {
+            if value == ffi::webrtc_DtlsTransportState_kNew {
+                DtlsTransportState::New
+            } else if value == ffi::webrtc_DtlsTransportState_kConnecting {
+                DtlsTransportState::Connecting
+            } else if value == ffi::webrtc_DtlsTransportState_kConnected {
+                DtlsTransportState::Connected
+            } else if value == ffi::webrtc_DtlsTransportState_kClosed {
+                DtlsTransportState::Closed
+            } else if value == ffi::webrtc_DtlsTransportState_kFailed {
+                DtlsTransportState::Failed
+            } else {
+                DtlsTransportState::Unknown(value)
+            }
+        }
+    }
+}
+
+/// DtlsTransportInterface のラッパー。
+pub struct DtlsTransport {
+    raw_ref: ScopedRef<DtlsTransportHandle>,
+}
+
+impl DtlsTransport {
+    pub(crate) fn from_scoped_ref(raw_ref: ScopedRef<DtlsTransportHandle>) -> Self {
+        Self { raw_ref }
+    }
+
+    /// DtlsTransport の状態を取得する。
+    pub fn state(&self) -> DtlsTransportState {
+        let state = unsafe { ffi::webrtc_DtlsTransportInterface_state(self.raw_ref.as_ptr()) };
+        DtlsTransportState::from_int(state)
+    }
+
+    /// Observer を登録する。
+    pub fn register_observer(&self, observer: &DtlsTransportObserver) {
+        unsafe {
+            ffi::webrtc_DtlsTransportInterface_RegisterObserver(
+                self.raw_ref.as_ptr(),
+                observer.as_ptr(),
+            )
+        };
+    }
+
+    /// Observer を解除する。
+    pub fn unregister_observer(&self) {
+        unsafe { ffi::webrtc_DtlsTransportInterface_UnregisterObserver(self.raw_ref.as_ptr()) };
+    }
+}
+
+unsafe impl Send for DtlsTransport {}
+unsafe impl Sync for DtlsTransport {}
+
+// -------------------------
+// DtlsTransportObserver
+// -------------------------
+
+pub trait DtlsTransportObserverHandler: Send {
+    #[expect(unused_variables)]
+    fn on_state_change(&mut self, new_state: DtlsTransportState) {}
+    fn on_error(&mut self) {}
+}
+
+impl DtlsTransportObserverHandler for () {}
+
+struct DtlsTransportObserverHandlerState {
+    handler: Box<dyn DtlsTransportObserverHandler>,
+}
+
+unsafe extern "C" fn dtls_observer_on_state_change(new_state: i32, user_data: *mut c_void) {
+    assert!(
+        !user_data.is_null(),
+        "dtls_observer_on_state_change: user_data is null"
+    );
+    let state = unsafe { &mut *(user_data as *mut DtlsTransportObserverHandlerState) };
+    state
+        .handler
+        .on_state_change(DtlsTransportState::from_int(new_state));
+}
+
+unsafe extern "C" fn dtls_observer_on_error(user_data: *mut c_void) {
+    assert!(
+        !user_data.is_null(),
+        "dtls_observer_on_error: user_data is null"
+    );
+    let state = unsafe { &mut *(user_data as *mut DtlsTransportObserverHandlerState) };
+    state.handler.on_error();
+}
+
+unsafe extern "C" fn dtls_observer_on_destroy(user_data: *mut c_void) {
+    assert!(
+        !user_data.is_null(),
+        "dtls_observer_on_destroy: user_data is null"
+    );
+    let _ = unsafe { Box::from_raw(user_data as *mut DtlsTransportObserverHandlerState) };
+}
+
+/// DtlsTransportObserver のラッパー。
+pub struct DtlsTransportObserver {
+    raw: NonNull<ffi::webrtc_DtlsTransportObserver>,
+}
+
+impl DtlsTransportObserver {
+    pub fn new_with_handler(handler: Box<dyn DtlsTransportObserverHandler>) -> Self {
+        let state = Box::new(DtlsTransportObserverHandlerState { handler });
+        let user_data = Box::into_raw(state) as *mut c_void;
+        let cbs = ffi::webrtc_DtlsTransportObserver_cbs {
+            OnStateChange: Some(dtls_observer_on_state_change),
+            OnError: Some(dtls_observer_on_error),
+            OnDestroy: Some(dtls_observer_on_destroy),
+        };
+        let raw = match NonNull::new(unsafe {
+            ffi::webrtc_DtlsTransportObserver_new(&cbs, user_data)
+        }) {
+            Some(raw) => raw,
+            None => {
+                let _ =
+                    unsafe { Box::from_raw(user_data as *mut DtlsTransportObserverHandlerState) };
+                panic!("BUG: webrtc_DtlsTransportObserver_new が null を返しました");
+            }
+        };
+        Self { raw }
+    }
+
+    pub fn as_ptr(&self) -> *mut ffi::webrtc_DtlsTransportObserver {
+        self.raw.as_ptr()
+    }
+}
+
+impl Drop for DtlsTransportObserver {
+    fn drop(&mut self) {
+        unsafe { ffi::webrtc_DtlsTransportObserver_delete(self.raw.as_ptr()) };
+    }
+}
+
+unsafe impl Send for DtlsTransportObserver {}
+unsafe impl Sync for DtlsTransportObserver {}

--- a/src/api/dtls_transport.rs
+++ b/src/api/dtls_transport.rs
@@ -67,7 +67,6 @@ impl DtlsTransport {
 }
 
 unsafe impl Send for DtlsTransport {}
-unsafe impl Sync for DtlsTransport {}
 
 // -------------------------
 // DtlsTransportObserver
@@ -152,4 +151,3 @@ impl Drop for DtlsTransportObserver {
 }
 
 unsafe impl Send for DtlsTransportObserver {}
-unsafe impl Sync for DtlsTransportObserver {}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,6 +1,7 @@
 mod audio;
 mod audio_device_module;
 mod data_channel;
+mod dtls_transport;
 mod environment;
 mod jsep;
 mod media_types;
@@ -17,6 +18,7 @@ mod video_encoder;
 pub use audio::*;
 pub use audio_device_module::*;
 pub use data_channel::*;
+pub use dtls_transport::*;
 pub use environment::*;
 pub use jsep::*;
 pub use media_types::*;

--- a/src/api/peer_connection.rs
+++ b/src/api/peer_connection.rs
@@ -1,13 +1,13 @@
 use crate::ref_count::{
     AudioTrackHandle, AudioTrackSourceHandle, ConnectionContextHandle, DataChannelHandle,
-    PeerConnectionFactoryHandle, PeerConnectionHandle, RtpReceiverHandle, RtpSenderHandle,
-    RtpTransceiverHandle, SetLocalDescriptionObserverHandle, SetRemoteDescriptionObserverHandle,
-    VideoTrackHandle,
+    DtlsTransportHandle, PeerConnectionFactoryHandle, PeerConnectionHandle, RtpReceiverHandle,
+    RtpSenderHandle, RtpTransceiverHandle, SetLocalDescriptionObserverHandle,
+    SetRemoteDescriptionObserverHandle, VideoTrackHandle,
 };
 use crate::{
     AudioDecoderFactory, AudioDeviceModule, AudioEncoderFactory, AudioProcessingBuilder,
-    AudioTrack, AudioTrackSource, CxxString, DataChannel, DataChannelInit, Error, IceCandidate,
-    IceCandidateRef, MediaStreamTrack, MediaType, RTCStatsReport, Result, RtcError,
+    AudioTrack, AudioTrackSource, CxxString, DataChannel, DataChannelInit, DtlsTransport, Error,
+    IceCandidate, IceCandidateRef, MediaStreamTrack, MediaType, RTCStatsReport, Result, RtcError,
     RtcEventLogFactory, RtpCapabilities, RtpReceiver, RtpSender, RtpTransceiver,
     RtpTransceiverInit, SSLCertificateVerifier, SSLIdentity, ScopedRef, SessionDescription,
     StringVector, Thread, VideoDecoderFactory, VideoEncoderFactory, VideoTrack, VideoTrackSource,
@@ -1832,6 +1832,21 @@ impl PeerConnection {
         unsafe {
             ffi::webrtc_PeerConnectionInterface_GetStats(self.raw_ref.as_ptr(), &mut cbs, user_data)
         };
+    }
+
+    /// mid に対応する DtlsTransport を取得する。
+    pub fn lookup_dtls_transport_by_mid(&self, mid: &str) -> Option<DtlsTransport> {
+        let ptr = unsafe {
+            ffi::webrtc_PeerConnectionInterface_LookupDtlsTransportByMid(
+                self.raw_ref.as_ptr(),
+                mid.as_ptr() as *const _,
+                mid.len(),
+            )
+        };
+        NonNull::new(ptr).map(|p| {
+            let raw_ref = ScopedRef::<DtlsTransportHandle>::from_raw(p);
+            DtlsTransport::from_scoped_ref(raw_ref)
+        })
     }
 
     pub fn as_ptr(&self) -> *mut ffi::webrtc_PeerConnectionInterface {

--- a/src/ref_count.rs
+++ b/src/ref_count.rs
@@ -297,6 +297,22 @@ impl RefCountedHandle for PeerConnectionHandle {
     }
 }
 
+pub(crate) struct DtlsTransportHandle;
+impl RefCountedHandle for DtlsTransportHandle {
+    type Refcounted = ffi::webrtc_DtlsTransportInterface_refcounted;
+    type Raw = ffi::webrtc_DtlsTransportInterface;
+
+    unsafe fn get(raw_ref: *mut Self::Refcounted) -> *mut Self::Raw {
+        unsafe { ffi::webrtc_DtlsTransportInterface_refcounted_get(raw_ref) }
+    }
+    unsafe fn add_ref(raw: *mut Self::Raw) {
+        unsafe { ffi::webrtc_DtlsTransportInterface_AddRef(raw) };
+    }
+    unsafe fn release(raw: *mut Self::Raw) {
+        unsafe { ffi::webrtc_DtlsTransportInterface_Release(raw) };
+    }
+}
+
 pub(crate) struct RTCStatsReportHandle;
 impl RefCountedHandle for RTCStatsReportHandle {
     type Refcounted = ffi::webrtc_RTCStatsReport_refcounted;

--- a/webrtc/src/webrtc_c/api/dtls_transport_interface.cc
+++ b/webrtc/src/webrtc_c/api/dtls_transport_interface.cc
@@ -31,3 +31,72 @@ WEBRTC_EXPORT webrtc_DtlsTransportState webrtc_DtlsTransportInterface_state(
       transport->Information().state());
 }
 }
+
+// -------------------------
+// webrtc::DtlsTransportObserverInterface
+// -------------------------
+
+class DtlsTransportObserverImpl
+    : public webrtc::DtlsTransportObserverInterface {
+ public:
+  DtlsTransportObserverImpl(const struct webrtc_DtlsTransportObserver_cbs* cbs,
+                            void* user_data)
+      : user_data_(user_data) {
+    if (cbs != nullptr) {
+      cbs_ = *cbs;
+    }
+  }
+
+  ~DtlsTransportObserverImpl() override {
+    if (cbs_.OnDestroy != nullptr) {
+      cbs_.OnDestroy(user_data_);
+    }
+  }
+
+  void OnStateChange(webrtc::DtlsTransportInformation info) override {
+    if (cbs_.OnStateChange != nullptr) {
+      cbs_.OnStateChange(static_cast<webrtc_DtlsTransportState>(info.state()),
+                         user_data_);
+    }
+  }
+
+  void OnError(webrtc::RTCError error) override {
+    if (cbs_.OnError != nullptr) {
+      cbs_.OnError(user_data_);
+    }
+  }
+
+ private:
+  webrtc_DtlsTransportObserver_cbs cbs_{};
+  void* user_data_;
+};
+
+extern "C" {
+WEBRTC_EXPORT struct webrtc_DtlsTransportObserver*
+webrtc_DtlsTransportObserver_new(
+    const struct webrtc_DtlsTransportObserver_cbs* cbs,
+    void* user_data) {
+  auto impl = new DtlsTransportObserverImpl(cbs, user_data);
+  return reinterpret_cast<struct webrtc_DtlsTransportObserver*>(impl);
+}
+
+WEBRTC_EXPORT void webrtc_DtlsTransportObserver_delete(
+    struct webrtc_DtlsTransportObserver* self) {
+  auto impl = reinterpret_cast<DtlsTransportObserverImpl*>(self);
+  delete impl;
+}
+
+WEBRTC_EXPORT void webrtc_DtlsTransportInterface_RegisterObserver(
+    struct webrtc_DtlsTransportInterface* self,
+    struct webrtc_DtlsTransportObserver* observer) {
+  auto transport = reinterpret_cast<webrtc::DtlsTransportInterface*>(self);
+  auto obs = reinterpret_cast<DtlsTransportObserverImpl*>(observer);
+  transport->RegisterObserver(obs);
+}
+
+WEBRTC_EXPORT void webrtc_DtlsTransportInterface_UnregisterObserver(
+    struct webrtc_DtlsTransportInterface* self) {
+  auto transport = reinterpret_cast<webrtc::DtlsTransportInterface*>(self);
+  transport->UnregisterObserver();
+}
+}

--- a/webrtc/src/webrtc_c/api/dtls_transport_interface.h
+++ b/webrtc/src/webrtc_c/api/dtls_transport_interface.h
@@ -22,6 +22,29 @@ WEBRTC_EXPORT extern const int webrtc_DtlsTransportState_kFailed;
 WEBRTC_EXPORT webrtc_DtlsTransportState
 webrtc_DtlsTransportInterface_state(struct webrtc_DtlsTransportInterface* self);
 
+// -------------------------
+// webrtc::DtlsTransportObserverInterface
+// -------------------------
+
+struct webrtc_DtlsTransportObserver;
+struct webrtc_DtlsTransportObserver_cbs {
+  void (*OnStateChange)(webrtc_DtlsTransportState new_state, void* user_data);
+  void (*OnError)(void* user_data);
+  void (*OnDestroy)(void* user_data);
+};
+WEBRTC_EXPORT struct webrtc_DtlsTransportObserver*
+webrtc_DtlsTransportObserver_new(
+    const struct webrtc_DtlsTransportObserver_cbs* cbs,
+    void* user_data);
+WEBRTC_EXPORT void webrtc_DtlsTransportObserver_delete(
+    struct webrtc_DtlsTransportObserver* self);
+
+WEBRTC_EXPORT void webrtc_DtlsTransportInterface_RegisterObserver(
+    struct webrtc_DtlsTransportInterface* self,
+    struct webrtc_DtlsTransportObserver* observer);
+WEBRTC_EXPORT void webrtc_DtlsTransportInterface_UnregisterObserver(
+    struct webrtc_DtlsTransportInterface* self);
+
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
## 概要

- `DtlsTransport` / `DtlsTransportObserver` / `DtlsTransportState` を追加する
- `PeerConnection::lookup_dtls_transport_by_mid` を追加する
  - `DtlsTransport` のインスタンスを取得するために必要

## 詳細

upstream libwebrtc の `DtlsTransportInterface` / `DtlsTransportObserverInterface` の薄いラッパー。

### C API 層 (libwebrtc-c / webrtc-rs 内 C コード)

- `webrtc_DtlsTransportObserver_cbs` コールバック構造体 (`OnStateChange`, `OnError`, `OnDestroy`)
- `webrtc_DtlsTransportObserver_new` / `_delete`
- `webrtc_DtlsTransportInterface_RegisterObserver` / `UnregisterObserver`

### Rust 層

- `DtlsTransportState` enum (`New`, `Connecting`, `Connected`, `Closed`, `Failed`)
- `DtlsTransport` 構造体 (`state()`, `register_observer()`, `unregister_observer()`)
- `DtlsTransportObserverHandler` trait (`on_state_change()`, `on_error()`)
- `DtlsTransportObserver` 構造体
- `PeerConnection::lookup_dtls_transport_by_mid()` メソッド

### 設計

- `OnStateChange` は upstream の `DtlsTransportInformation` から `state` のみを取り出して int で渡す
- `OnError` は upstream と同じく `OnStateChange` とは独立したコールバック
- 既存の `DataChannelObserver` と同一パターンに準拠
- panic は `_new` が null を返した場合のみで、C 側の実装上到達不能。既存コード全体で同じ方針