### PR TITLE
VideoFrameBuffer を扱えるようにしてユーザー側でカスタム可能にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@
   - `NV12Buffer` を追加し、`y_data` / `uv_data` の参照と `crop_and_scale_from` を利用できるようにする
   - `NV12Buffer` から `VideoFrameBuffer` への変換と `kind == Nv12` の取り扱いを追加する
   - @melpon
+- [ADD] `I420Buffer` / `NV12Buffer` に `chroma_width` / `chroma_height` を追加する
+  - `I420Buffer` / `NV12Buffer` の C API と Rust API から、4:2:0 の chroma 解像度を切り上げ半分で取得できるようにする
+  - `u_data` / `v_data` / `uv_data` の平面長計算を `chroma_height` 利用へ統一する
+  - @melpon
 - [CHANGE] `VideoFrame` の生成 API を `VideoFrameBuffer` ベースに変更する
   - `VideoFrameBuffer` / `VideoFrameBufferHandler` を追加し、Rust 実装の native バッファを `kNative` として扱えるようにする
   - `VideoFrameBufferKind` と `VideoFrameBuffer::kind` / `VideoFrameBufferHandler::kind` を追加し、バッファ種別を Rust 側で扱えるようにする

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,11 +11,9 @@
 
 ## develop
 
-- [ADD] `NV12Buffer` の C API / Rust API を追加する
+- [ADD] `NV12Buffer` と関連バッファ API を追加する
   - `NV12Buffer` を追加し、`y_data` / `uv_data` の参照と `crop_and_scale_from` を利用できるようにする
   - `NV12Buffer` から `VideoFrameBuffer` への変換と `kind == Nv12` の取り扱いを追加する
-  - @melpon
-- [ADD] `I420Buffer` / `NV12Buffer` に `chroma_width` / `chroma_height` を追加する
   - `I420Buffer` / `NV12Buffer` の C API と Rust API から、4:2:0 の chroma 解像度を切り上げ半分で取得できるようにする
   - `u_data` / `v_data` / `uv_data` の平面長計算を `chroma_height` 利用へ統一する
   - @melpon
@@ -27,13 +25,13 @@
   - `VideoFrameBuffer` / `VideoFrameBufferHandler` を追加し、Rust 実装の native バッファを `kNative` として扱えるようにする
   - `VideoFrameBufferKind` と `VideoFrameBuffer::kind` / `VideoFrameBufferHandler::kind` を追加し、バッファ種別を Rust 側で扱えるようにする
   - `VideoFrameBuffer::crop_and_scale` / `VideoFrameBuffer::scale` と `VideoFrameBufferHandler::crop_and_scale` を追加し、Rust 側で `CropAndScale` / `Scale` を利用できるようにする
+  - C API `webrtc_VideoFrameBuffer_get_user_data` と `webrtc_VideoFrameBuffer_cast_to_webrtc_I420Buffer` / `webrtc_VideoFrameBuffer_cast_to_webrtc_NV12Buffer` を追加する
+  - Rust 側で `VideoFrameBuffer::as_native_ref` / `VideoFrameBuffer::as_native_mut` / `VideoFrameBuffer::as_i420` / `VideoFrameBuffer::as_nv12` を追加する
   - `VideoFrame::from_i420` を削除し、`VideoFrame::from_buffer` を追加する
   - `VideoFrame::buffer` / `VideoFrameRef::buffer` の戻り値を `VideoFrameBuffer` に変更する
   - @melpon
-- [CHANGE] `I420Buffer` の convenience API を削除する
+- [CHANGE] `I420Buffer` / `NV12` 変換 API をバッファ中心に統一する
   - `I420Buffer::fill_y` と `I420Buffer::fill_uv` を削除し、平面書き込みを `y_data_mut` / `u_data_mut` / `v_data_mut` に統一する
-  - @melpon
-- [CHANGE] `i420_to_nv12` / `nv12_to_i420` の入出力型を `NV12Buffer` ベースに変更する
   - `i420_to_nv12` の戻り値を `Option<NV12Buffer>` に変更し、NV12 平面の手動分割を不要にする
   - `nv12_to_i420` の引数を `&NV12Buffer` に変更し、NV12 平面ポインタと stride の手動指定を不要にする
   - @melpon

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,10 @@
   - `I420Buffer` / `NV12Buffer` の C API と Rust API から、4:2:0 の chroma 解像度を切り上げ半分で取得できるようにする
   - `u_data` / `v_data` / `uv_data` の平面長計算を `chroma_height` 利用へ統一する
   - @melpon
+- [ADD] `VideoFrame` の複製 API を追加する
+  - C API `webrtc_VideoFrame_copy` を追加する
+  - Rust 側で `VideoFrame: Clone` と `VideoFrameRef::to_owned` を追加する
+  - @melpon
 - [CHANGE] `VideoFrame` の生成 API を `VideoFrameBuffer` ベースに変更する
   - `VideoFrameBuffer` / `VideoFrameBufferHandler` を追加し、Rust 実装の native バッファを `kNative` として扱えるようにする
   - `VideoFrameBufferKind` と `VideoFrameBuffer::kind` / `VideoFrameBufferHandler::kind` を追加し、バッファ種別を Rust 側で扱えるようにする

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,9 @@
   - `VideoFrame::from_i420` を削除し、`VideoFrame::from_buffer` を追加する
   - `VideoFrame::buffer` / `VideoFrameRef::buffer` の戻り値を `VideoFrameBuffer` に変更する
   - @melpon
+- [CHANGE] `I420Buffer` の convenience API を削除する
+  - `I420Buffer::fill_y` と `I420Buffer::fill_uv` を削除し、平面書き込みを `y_data_mut` / `u_data_mut` / `v_data_mut` に統一する
+  - @melpon
 
 ## 0.146.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 ## develop
 
+- [ADD] `NV12Buffer` の C API / Rust API を追加する
+  - `NV12Buffer` を追加し、`y_data` / `uv_data` の参照と `crop_and_scale_from` を利用できるようにする
+  - `NV12Buffer` から `VideoFrameBuffer` への変換と `kind == Nv12` の取り扱いを追加する
+  - @melpon
 - [CHANGE] `VideoFrame` の生成 API を `VideoFrameBuffer` ベースに変更する
   - `VideoFrameBuffer` / `VideoFrameBufferHandler` を追加し、Rust 実装の native バッファを `kNative` として扱えるようにする
   - `VideoFrameBufferKind` と `VideoFrameBuffer::kind` / `VideoFrameBufferHandler::kind` を追加し、バッファ種別を Rust 側で扱えるようにする

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - [CHANGE] `VideoFrame` の生成 API を `VideoFrameBuffer` ベースに変更する
   - `VideoFrameBuffer` / `VideoFrameBufferHandler` を追加し、Rust 実装の native バッファを `kNative` として扱えるようにする
   - `VideoFrameBufferKind` と `VideoFrameBuffer::kind` / `VideoFrameBufferHandler::kind` を追加し、バッファ種別を Rust 側で扱えるようにする
+  - `VideoFrameBuffer::crop_and_scale` / `VideoFrameBuffer::scale` と `VideoFrameBufferHandler::crop_and_scale` を追加し、Rust 側で `CropAndScale` / `Scale` を利用できるようにする
   - `VideoFrame::from_i420` を削除し、`VideoFrame::from_buffer` を追加する
   - `VideoFrame::buffer` / `VideoFrameRef::buffer` の戻り値を `VideoFrameBuffer` に変更する
   - @melpon

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,13 @@
 
 ## develop
 
+- [CHANGE] `VideoFrame` の生成 API を `VideoFrameBuffer` ベースに変更する
+  - `VideoFrameBuffer` / `VideoFrameBufferHandler` を追加し、Rust 実装の native バッファを `kNative` として扱えるようにする
+  - `VideoFrameBufferKind` と `VideoFrameBuffer::kind` / `VideoFrameBufferHandler::kind` を追加し、バッファ種別を Rust 側で扱えるようにする
+  - `VideoFrame::from_i420` を削除し、`VideoFrame::from_buffer` を追加する
+  - `VideoFrame::buffer` / `VideoFrameRef::buffer` の戻り値を `VideoFrameBuffer` に変更する
+  - @melpon
+
 ## 0.146.2
 
 **リリース日**: 2026-03-27

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,10 @@
 - [CHANGE] `I420Buffer` の convenience API を削除する
   - `I420Buffer::fill_y` と `I420Buffer::fill_uv` を削除し、平面書き込みを `y_data_mut` / `u_data_mut` / `v_data_mut` に統一する
   - @melpon
+- [CHANGE] `i420_to_nv12` / `nv12_to_i420` の入出力型を `NV12Buffer` ベースに変更する
+  - `i420_to_nv12` の戻り値を `Option<NV12Buffer>` に変更し、NV12 平面の手動分割を不要にする
+  - `nv12_to_i420` の引数を `&NV12Buffer` に変更し、NV12 平面ポインタと stride の手動指定を不要にする
+  - @melpon
 
 ## 0.146.2
 

--- a/examples/whep/src/main.rs
+++ b/examples/whep/src/main.rs
@@ -112,7 +112,11 @@ fn rgb_to_ansi256(r: u8, g: u8, b: u8) -> i32 {
 }
 
 fn render_frame(frame: VideoFrameRef, width: i32, height: i32) {
-    let src = frame.buffer();
+    let mut src = frame.buffer();
+    let src = match src.to_i420() {
+        Some(src) => src,
+        None => return,
+    };
     let mut scaled = I420Buffer::new(width, height);
     scaled.scale_from(&src);
 

--- a/examples/whip/src/main.rs
+++ b/examples/whip/src/main.rs
@@ -255,21 +255,22 @@ fn tick_once(
 
     if let Some(buffer) = abgr_to_i420(u32_slice_as_u8_slice(image), width, height) {
         let timestamp_us = elapsed_ms * 1000;
-        let frame = VideoFrame::from_i420(&buffer, timestamp_us, 0);
         let AdaptFrameResult { applied, size } = source.adapt_frame(width, height, timestamp_us);
         let frame = if applied
-            && (size.adapted_width != frame.width() || size.adapted_height != frame.height())
+            && (size.adapted_width != buffer.width() || size.adapted_height != buffer.height())
         {
             let mut scaled = I420Buffer::new(size.adapted_width, size.adapted_height);
             scaled.scale_from(&buffer);
-            VideoFrame::from_i420(
-                &scaled,
+            let scaled_buffer = scaled.cast_to_video_frame_buffer();
+            VideoFrame::from_buffer(
+                &scaled_buffer,
                 timestamp_aligner.translate(timestamp_us, time_millis() * 1000),
                 0,
             )
         } else {
-            VideoFrame::from_i420(
-                &buffer,
+            let frame_buffer = buffer.cast_to_video_frame_buffer();
+            VideoFrame::from_buffer(
+                &frame_buffer,
                 timestamp_aligner.translate(timestamp_us, time_millis() * 1000),
                 0,
             )

--- a/src/api/video_codec_common.rs
+++ b/src/api/video_codec_common.rs
@@ -1,7 +1,8 @@
-use crate::ref_count::{EncodedImageBufferHandle, I420BufferHandle};
+use crate::ref_count::{EncodedImageBufferHandle, I420BufferHandle, VideoFrameBufferHandle};
 use crate::{CxxString, CxxStringRef, Error, MapStringString, Result, ScopedRef, ffi};
 use std::collections::HashMap;
 use std::marker::PhantomData;
+use std::os::raw::c_void;
 use std::ptr::NonNull;
 use std::slice;
 
@@ -409,8 +410,242 @@ impl I420Buffer {
         self.raw_ref.as_refcounted_ptr()
     }
 
+    fn from_raw_ref(raw_ref: NonNull<ffi::webrtc_I420Buffer_refcounted>) -> Self {
+        let raw_ref = ScopedRef::<I420BufferHandle>::from_raw(raw_ref);
+        Self { raw_ref }
+    }
+
+    fn into_raw_refcounted(self) -> *mut ffi::webrtc_I420Buffer_refcounted {
+        let this = std::mem::ManuallyDrop::new(self);
+        this.raw_ref.as_refcounted_ptr()
+    }
+
+    pub fn cast_to_video_frame_buffer(&self) -> VideoFrameBuffer {
+        let raw_ref = NonNull::new(unsafe {
+            ffi::webrtc_I420Buffer_refcounted_cast_to_webrtc_VideoFrameBuffer(
+                self.raw_ref.as_refcounted_ptr(),
+            )
+        })
+        .expect("BUG: webrtc_I420Buffer_refcounted_cast_to_webrtc_VideoFrameBuffer returned null");
+        let raw_ref = ScopedRef::<VideoFrameBufferHandle>::from_raw(raw_ref);
+        VideoFrameBuffer { raw_ref }
+    }
+
     pub(crate) fn raw(&self) -> NonNull<ffi::webrtc_I420Buffer> {
         self.raw_ref.raw()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VideoFrameBufferKind {
+    Native,
+    I420,
+    I420A,
+    I422,
+    I444,
+    I010,
+    I210,
+    I410,
+    Nv12,
+    Unknown(i32),
+}
+
+impl VideoFrameBufferKind {
+    pub(crate) fn from_raw(value: i32) -> Self {
+        unsafe {
+            if value == ffi::webrtc_VideoFrameBuffer_Type_kNative {
+                Self::Native
+            } else if value == ffi::webrtc_VideoFrameBuffer_Type_kI420 {
+                Self::I420
+            } else if value == ffi::webrtc_VideoFrameBuffer_Type_kI420A {
+                Self::I420A
+            } else if value == ffi::webrtc_VideoFrameBuffer_Type_kI422 {
+                Self::I422
+            } else if value == ffi::webrtc_VideoFrameBuffer_Type_kI444 {
+                Self::I444
+            } else if value == ffi::webrtc_VideoFrameBuffer_Type_kI010 {
+                Self::I010
+            } else if value == ffi::webrtc_VideoFrameBuffer_Type_kI210 {
+                Self::I210
+            } else if value == ffi::webrtc_VideoFrameBuffer_Type_kI410 {
+                Self::I410
+            } else if value == ffi::webrtc_VideoFrameBuffer_Type_kNV12 {
+                Self::Nv12
+            } else {
+                Self::Unknown(value)
+            }
+        }
+    }
+
+    pub(crate) fn to_raw(self) -> i32 {
+        unsafe {
+            match self {
+                Self::Native => ffi::webrtc_VideoFrameBuffer_Type_kNative,
+                Self::I420 => ffi::webrtc_VideoFrameBuffer_Type_kI420,
+                Self::I420A => ffi::webrtc_VideoFrameBuffer_Type_kI420A,
+                Self::I422 => ffi::webrtc_VideoFrameBuffer_Type_kI422,
+                Self::I444 => ffi::webrtc_VideoFrameBuffer_Type_kI444,
+                Self::I010 => ffi::webrtc_VideoFrameBuffer_Type_kI010,
+                Self::I210 => ffi::webrtc_VideoFrameBuffer_Type_kI210,
+                Self::I410 => ffi::webrtc_VideoFrameBuffer_Type_kI410,
+                Self::Nv12 => ffi::webrtc_VideoFrameBuffer_Type_kNV12,
+                Self::Unknown(v) => v,
+            }
+        }
+    }
+}
+
+pub trait VideoFrameBufferHandler: Send {
+    fn kind(&mut self) -> VideoFrameBufferKind {
+        VideoFrameBufferKind::Native
+    }
+    fn width(&mut self) -> i32;
+    fn height(&mut self) -> i32;
+    fn to_i420(&mut self) -> Option<I420Buffer>;
+}
+
+struct VideoFrameBufferHandlerState {
+    handler: Box<dyn VideoFrameBufferHandler>,
+    #[cfg(debug_assertions)]
+    callback_thread: Option<std::thread::ThreadId>,
+}
+
+#[cfg(debug_assertions)]
+fn assert_video_frame_buffer_handler_thread(state: &mut VideoFrameBufferHandlerState) {
+    let current = std::thread::current().id();
+    if let Some(thread) = state.callback_thread {
+        assert_eq!(
+            thread, current,
+            "video_frame_buffer callback called from multiple threads",
+        );
+    } else {
+        state.callback_thread = Some(current);
+    }
+}
+
+unsafe extern "C" fn video_frame_buffer_type(user_data: *mut c_void) -> i32 {
+    assert!(
+        !user_data.is_null(),
+        "video_frame_buffer_type: user_data is null"
+    );
+    let state = unsafe { &mut *(user_data as *mut VideoFrameBufferHandlerState) };
+    #[cfg(debug_assertions)]
+    assert_video_frame_buffer_handler_thread(state);
+    state.handler.kind().to_raw()
+}
+
+unsafe extern "C" fn video_frame_buffer_width(user_data: *mut c_void) -> i32 {
+    assert!(
+        !user_data.is_null(),
+        "video_frame_buffer_width: user_data is null"
+    );
+    let state = unsafe { &mut *(user_data as *mut VideoFrameBufferHandlerState) };
+    #[cfg(debug_assertions)]
+    assert_video_frame_buffer_handler_thread(state);
+    state.handler.width()
+}
+
+unsafe extern "C" fn video_frame_buffer_height(user_data: *mut c_void) -> i32 {
+    assert!(
+        !user_data.is_null(),
+        "video_frame_buffer_height: user_data is null"
+    );
+    let state = unsafe { &mut *(user_data as *mut VideoFrameBufferHandlerState) };
+    #[cfg(debug_assertions)]
+    assert_video_frame_buffer_handler_thread(state);
+    state.handler.height()
+}
+
+unsafe extern "C" fn video_frame_buffer_to_i420(
+    user_data: *mut c_void,
+) -> *mut ffi::webrtc_I420Buffer_refcounted {
+    assert!(
+        !user_data.is_null(),
+        "video_frame_buffer_to_i420: user_data is null"
+    );
+    let state = unsafe { &mut *(user_data as *mut VideoFrameBufferHandlerState) };
+    #[cfg(debug_assertions)]
+    assert_video_frame_buffer_handler_thread(state);
+    match state.handler.to_i420() {
+        Some(buffer) => buffer.into_raw_refcounted(),
+        None => std::ptr::null_mut(),
+    }
+}
+
+unsafe extern "C" fn video_frame_buffer_on_destroy(user_data: *mut c_void) {
+    assert!(
+        !user_data.is_null(),
+        "video_frame_buffer_on_destroy: user_data is null"
+    );
+    let _ = unsafe { Box::from_raw(user_data as *mut VideoFrameBufferHandlerState) };
+}
+
+/// webrtc::VideoFrameBuffer のラッパー。
+pub struct VideoFrameBuffer {
+    raw_ref: ScopedRef<VideoFrameBufferHandle>,
+}
+
+impl VideoFrameBuffer {
+    pub fn new_with_handler(handler: Box<dyn VideoFrameBufferHandler>) -> Self {
+        let state = Box::new(VideoFrameBufferHandlerState {
+            handler,
+            #[cfg(debug_assertions)]
+            callback_thread: None,
+        });
+        let user_data = Box::into_raw(state) as *mut c_void;
+        let cbs = ffi::webrtc_VideoFrameBuffer_cbs {
+            type_: Some(video_frame_buffer_type),
+            width: Some(video_frame_buffer_width),
+            height: Some(video_frame_buffer_height),
+            ToI420: Some(video_frame_buffer_to_i420),
+            OnDestroy: Some(video_frame_buffer_on_destroy),
+        };
+        let raw_ref = match NonNull::new(unsafe {
+            ffi::webrtc_VideoFrameBuffer_make_ref_counted(&cbs, user_data)
+        }) {
+            Some(raw_ref) => raw_ref,
+            None => {
+                let _ = unsafe { Box::from_raw(user_data as *mut VideoFrameBufferHandlerState) };
+                panic!("BUG: webrtc_VideoFrameBuffer_make_ref_counted returned null");
+            }
+        };
+        let raw_ref = ScopedRef::<VideoFrameBufferHandle>::from_raw(raw_ref);
+        Self { raw_ref }
+    }
+
+    pub fn width(&self) -> i32 {
+        unsafe { ffi::webrtc_VideoFrameBuffer_width(self.raw().as_ptr()) }
+    }
+
+    pub fn height(&self) -> i32 {
+        unsafe { ffi::webrtc_VideoFrameBuffer_height(self.raw().as_ptr()) }
+    }
+
+    pub fn kind(&self) -> VideoFrameBufferKind {
+        let value = unsafe { ffi::webrtc_VideoFrameBuffer_type(self.raw().as_ptr()) };
+        VideoFrameBufferKind::from_raw(value)
+    }
+
+    pub fn to_i420(&mut self) -> Option<I420Buffer> {
+        let raw_ref =
+            NonNull::new(unsafe { ffi::webrtc_VideoFrameBuffer_ToI420(self.raw().as_ptr()) })?;
+        Some(I420Buffer::from_raw_ref(raw_ref))
+    }
+
+    pub fn as_refcounted_ptr(&self) -> *mut ffi::webrtc_VideoFrameBuffer_refcounted {
+        self.raw_ref.as_refcounted_ptr()
+    }
+
+    pub(crate) fn raw(&self) -> NonNull<ffi::webrtc_VideoFrameBuffer> {
+        self.raw_ref.raw()
+    }
+}
+
+impl Clone for VideoFrameBuffer {
+    fn clone(&self) -> Self {
+        Self {
+            raw_ref: ScopedRef::clone(&self.raw_ref),
+        }
     }
 }
 
@@ -420,7 +655,7 @@ pub struct VideoFrame {
 }
 
 impl VideoFrame {
-    pub fn from_i420(buffer: &I420Buffer, timestamp_us: i64, timestamp_rtp: u32) -> Self {
+    pub fn from_buffer(buffer: &VideoFrameBuffer, timestamp_us: i64, timestamp_rtp: u32) -> Self {
         let raw = NonNull::new(unsafe {
             ffi::webrtc_VideoFrame_Create(
                 buffer.as_refcounted_ptr(),
@@ -449,8 +684,8 @@ impl VideoFrame {
         self.as_ref().rtp_timestamp()
     }
 
-    /// I420Buffer を取得する。
-    pub fn buffer(&self) -> I420Buffer {
+    /// VideoFrameBuffer を取得する。
+    pub fn buffer(&self) -> VideoFrameBuffer {
         self.as_ref().buffer()
     }
 
@@ -505,12 +740,12 @@ impl<'a> VideoFrameRef<'a> {
         unsafe { ffi::webrtc_VideoFrame_timestamp_rtp(self.raw.as_ptr()) }
     }
 
-    pub fn buffer(&self) -> I420Buffer {
+    pub fn buffer(&self) -> VideoFrameBuffer {
         let buf =
             NonNull::new(unsafe { ffi::webrtc_VideoFrame_video_frame_buffer(self.raw.as_ptr()) })
                 .expect("BUG: webrtc_VideoFrame_video_frame_buffer が null を返しました");
-        let raw_ref = ScopedRef::<I420BufferHandle>::from_raw(buf);
-        I420Buffer { raw_ref }
+        let raw_ref = ScopedRef::<VideoFrameBufferHandle>::from_raw(buf);
+        VideoFrameBuffer { raw_ref }
     }
 
     pub(crate) fn as_ptr(&self) -> *mut ffi::webrtc_VideoFrame {

--- a/src/api/video_codec_common.rs
+++ b/src/api/video_codec_common.rs
@@ -312,6 +312,14 @@ impl I420Buffer {
         unsafe { ffi::webrtc_I420Buffer_height(self.raw().as_ptr()) }
     }
 
+    pub fn chroma_width(&self) -> i32 {
+        unsafe { ffi::webrtc_I420Buffer_chroma_width(self.raw().as_ptr()) }
+    }
+
+    pub fn chroma_height(&self) -> i32 {
+        unsafe { ffi::webrtc_I420Buffer_chroma_height(self.raw().as_ptr()) }
+    }
+
     pub fn stride_y(&self) -> i32 {
         let raw = self.raw();
         unsafe { ffi::webrtc_I420Buffer_StrideY(raw.as_ptr()) }
@@ -357,7 +365,7 @@ impl I420Buffer {
         let raw = self.raw();
         let ptr = unsafe { ffi::webrtc_I420Buffer_MutableDataU(raw.as_ptr()) };
         let stride = unsafe { ffi::webrtc_I420Buffer_StrideU(raw.as_ptr()) } as usize;
-        let h = (self.height() as usize).div_ceil(2);
+        let h = self.chroma_height() as usize;
         unsafe { slice::from_raw_parts(ptr, stride * h) }
     }
 
@@ -366,7 +374,7 @@ impl I420Buffer {
         let raw = self.raw();
         let ptr = unsafe { ffi::webrtc_I420Buffer_MutableDataU(raw.as_ptr()) };
         let stride = unsafe { ffi::webrtc_I420Buffer_StrideU(raw.as_ptr()) } as usize;
-        let h = (self.height() as usize).div_ceil(2);
+        let h = self.chroma_height() as usize;
         unsafe { slice::from_raw_parts_mut(ptr, stride * h) }
     }
 
@@ -375,7 +383,7 @@ impl I420Buffer {
         let raw = self.raw();
         let ptr = unsafe { ffi::webrtc_I420Buffer_MutableDataV(raw.as_ptr()) };
         let stride = unsafe { ffi::webrtc_I420Buffer_StrideV(raw.as_ptr()) } as usize;
-        let h = (self.height() as usize).div_ceil(2);
+        let h = self.chroma_height() as usize;
         unsafe { slice::from_raw_parts(ptr, stride * h) }
     }
 
@@ -384,7 +392,7 @@ impl I420Buffer {
         let raw = self.raw();
         let ptr = unsafe { ffi::webrtc_I420Buffer_MutableDataV(raw.as_ptr()) };
         let stride = unsafe { ffi::webrtc_I420Buffer_StrideV(raw.as_ptr()) } as usize;
-        let h = (self.height() as usize).div_ceil(2);
+        let h = self.chroma_height() as usize;
         unsafe { slice::from_raw_parts_mut(ptr, stride * h) }
     }
 
@@ -437,6 +445,14 @@ impl NV12Buffer {
 
     pub fn height(&self) -> i32 {
         unsafe { ffi::webrtc_NV12Buffer_height(self.raw().as_ptr()) }
+    }
+
+    pub fn chroma_width(&self) -> i32 {
+        unsafe { ffi::webrtc_NV12Buffer_chroma_width(self.raw().as_ptr()) }
+    }
+
+    pub fn chroma_height(&self) -> i32 {
+        unsafe { ffi::webrtc_NV12Buffer_chroma_height(self.raw().as_ptr()) }
     }
 
     pub fn stride_y(&self) -> i32 {
@@ -494,7 +510,7 @@ impl NV12Buffer {
         let raw = self.raw();
         let ptr = unsafe { ffi::webrtc_NV12Buffer_MutableDataUV(raw.as_ptr()) };
         let stride = unsafe { ffi::webrtc_NV12Buffer_StrideUV(raw.as_ptr()) } as usize;
-        let h = (self.height() as usize).div_ceil(2);
+        let h = self.chroma_height() as usize;
         unsafe { slice::from_raw_parts(ptr, stride * h) }
     }
 
@@ -503,7 +519,7 @@ impl NV12Buffer {
         let raw = self.raw();
         let ptr = unsafe { ffi::webrtc_NV12Buffer_MutableDataUV(raw.as_ptr()) };
         let stride = unsafe { ffi::webrtc_NV12Buffer_StrideUV(raw.as_ptr()) } as usize;
-        let h = (self.height() as usize).div_ceil(2);
+        let h = self.chroma_height() as usize;
         unsafe { slice::from_raw_parts_mut(ptr, stride * h) }
     }
 

--- a/src/api/video_codec_common.rs
+++ b/src/api/video_codec_common.rs
@@ -482,6 +482,19 @@ pub trait VideoFrameBufferHandler: Send {
     fn width(&mut self) -> i32;
     fn height(&mut self) -> i32;
     fn to_i420(&mut self) -> Option<I420Buffer>;
+    // None を返すとデフォルトの実装が呼ばれる。
+    // デフォルトの実装は to_i420() で I420Buffer を作成してからそれをクロップ＆スケールする。
+    fn crop_and_scale(
+        &mut self,
+        _offset_x: i32,
+        _offset_y: i32,
+        _crop_width: i32,
+        _crop_height: i32,
+        _scaled_width: i32,
+        _scaled_height: i32,
+    ) -> Option<VideoFrameBuffer> {
+        None
+    }
 }
 
 struct VideoFrameBufferHandlerState {
@@ -552,6 +565,40 @@ unsafe extern "C" fn video_frame_buffer_to_i420(
     }
 }
 
+unsafe extern "C" fn video_frame_buffer_crop_and_scale(
+    raw: *mut ffi::webrtc_VideoFrameBuffer,
+    offset_x: i32,
+    offset_y: i32,
+    crop_width: i32,
+    crop_height: i32,
+    scaled_width: i32,
+    scaled_height: i32,
+    user_data: *mut c_void,
+) -> *mut ffi::webrtc_VideoFrameBuffer_refcounted {
+    assert!(
+        !raw.is_null(),
+        "video_frame_buffer_crop_and_scale: raw is null"
+    );
+    assert!(
+        !user_data.is_null(),
+        "video_frame_buffer_crop_and_scale: user_data is null"
+    );
+    let state = unsafe { &mut *(user_data as *mut VideoFrameBufferHandlerState) };
+    #[cfg(debug_assertions)]
+    assert_video_frame_buffer_handler_thread(state);
+    if let Some(buffer) = state.handler.crop_and_scale(
+        offset_x,
+        offset_y,
+        crop_width,
+        crop_height,
+        scaled_width,
+        scaled_height,
+    ) {
+        return buffer.into_raw_refcounted();
+    }
+    std::ptr::null_mut()
+}
+
 unsafe extern "C" fn video_frame_buffer_on_destroy(user_data: *mut c_void) {
     assert!(
         !user_data.is_null(),
@@ -578,6 +625,7 @@ impl VideoFrameBuffer {
             width: Some(video_frame_buffer_width),
             height: Some(video_frame_buffer_height),
             ToI420: Some(video_frame_buffer_to_i420),
+            CropAndScale: Some(video_frame_buffer_crop_and_scale),
             OnDestroy: Some(video_frame_buffer_on_destroy),
         };
         let raw_ref = match NonNull::new(unsafe {
@@ -612,12 +660,65 @@ impl VideoFrameBuffer {
         Some(I420Buffer::from_raw_ref(raw_ref))
     }
 
+    pub fn crop_and_scale(
+        &mut self,
+        offset_x: i32,
+        offset_y: i32,
+        crop_width: i32,
+        crop_height: i32,
+        scaled_width: i32,
+        scaled_height: i32,
+    ) -> Option<VideoFrameBuffer> {
+        let raw_ref = NonNull::new(unsafe {
+            ffi::webrtc_VideoFrameBuffer_CropAndScale(
+                self.raw().as_ptr(),
+                offset_x,
+                offset_y,
+                crop_width,
+                crop_height,
+                scaled_width,
+                scaled_height,
+            )
+        })
+        .or_else(|| {
+            NonNull::new(unsafe {
+                ffi::webrtc_VideoFrameBuffer_DefaultCropAndScale(
+                    self.raw().as_ptr(),
+                    offset_x,
+                    offset_y,
+                    crop_width,
+                    crop_height,
+                    scaled_width,
+                    scaled_height,
+                )
+            })
+        })?;
+        let raw_ref = ScopedRef::<VideoFrameBufferHandle>::from_raw(raw_ref);
+        Some(VideoFrameBuffer { raw_ref })
+    }
+
+    pub fn scale(&mut self, scaled_width: i32, scaled_height: i32) -> Option<VideoFrameBuffer> {
+        self.crop_and_scale(
+            0,
+            0,
+            self.width(),
+            self.height(),
+            scaled_width,
+            scaled_height,
+        )
+    }
+
     pub fn as_refcounted_ptr(&self) -> *mut ffi::webrtc_VideoFrameBuffer_refcounted {
         self.raw_ref.as_refcounted_ptr()
     }
 
     pub(crate) fn raw(&self) -> NonNull<ffi::webrtc_VideoFrameBuffer> {
         self.raw_ref.raw()
+    }
+
+    fn into_raw_refcounted(self) -> *mut ffi::webrtc_VideoFrameBuffer_refcounted {
+        let this = std::mem::ManuallyDrop::new(self);
+        this.raw_ref.as_refcounted_ptr()
     }
 }
 

--- a/src/api/video_codec_common.rs
+++ b/src/api/video_codec_common.rs
@@ -625,11 +625,11 @@ impl<T: Any> VideoFrameBufferHandlerAny for T {
 }
 
 pub trait VideoFrameBufferHandler: Send + VideoFrameBufferHandlerAny {
-    fn kind(&mut self) -> VideoFrameBufferKind {
+    fn kind(&self) -> VideoFrameBufferKind {
         VideoFrameBufferKind::Native
     }
-    fn width(&mut self) -> i32;
-    fn height(&mut self) -> i32;
+    fn width(&self) -> i32;
+    fn height(&self) -> i32;
     fn to_i420(&mut self) -> Option<I420Buffer>;
     // None を返すとデフォルトの実装が呼ばれる。
     // デフォルトの実装は to_i420() で I420Buffer を作成してからそれをクロップ＆スケールする。

--- a/src/api/video_codec_common.rs
+++ b/src/api/video_codec_common.rs
@@ -2,6 +2,7 @@ use crate::ref_count::{
     EncodedImageBufferHandle, I420BufferHandle, NV12BufferHandle, VideoFrameBufferHandle,
 };
 use crate::{CxxString, CxxStringRef, Error, MapStringString, Result, ScopedRef, ffi};
+use std::any::Any;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::os::raw::c_void;
@@ -527,6 +528,11 @@ impl NV12Buffer {
         self.raw_ref.as_refcounted_ptr()
     }
 
+    fn from_raw_ref(raw_ref: NonNull<ffi::webrtc_NV12Buffer_refcounted>) -> Self {
+        let raw_ref = ScopedRef::<NV12BufferHandle>::from_raw(raw_ref);
+        Self { raw_ref }
+    }
+
     pub fn cast_to_video_frame_buffer(&self) -> VideoFrameBuffer {
         let raw_ref = NonNull::new(unsafe {
             ffi::webrtc_NV12Buffer_refcounted_cast_to_webrtc_VideoFrameBuffer(
@@ -602,7 +608,23 @@ impl VideoFrameBufferKind {
     }
 }
 
-pub trait VideoFrameBufferHandler: Send {
+#[doc(hidden)]
+pub trait VideoFrameBufferHandlerAny {
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+impl<T: Any> VideoFrameBufferHandlerAny for T {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+pub trait VideoFrameBufferHandler: Send + VideoFrameBufferHandlerAny {
     fn kind(&mut self) -> VideoFrameBufferKind {
         VideoFrameBufferKind::Native
     }
@@ -779,6 +801,44 @@ impl VideoFrameBuffer {
     pub fn kind(&self) -> VideoFrameBufferKind {
         let value = unsafe { ffi::webrtc_VideoFrameBuffer_type(self.raw().as_ptr()) };
         VideoFrameBufferKind::from_raw(value)
+    }
+
+    /// # Safety
+    /// 同一実体の `VideoFrameBuffer` へ同時アクセスしないこと。
+    /// 特に callback 側や別 clone から mutable にアクセスされないことを呼び出し側が保証する必要があります。
+    pub unsafe fn as_native_ref<T: VideoFrameBufferHandler + 'static>(&self) -> Option<&T> {
+        let user_data = unsafe { ffi::webrtc_VideoFrameBuffer_get_user_data(self.raw().as_ptr()) };
+        if user_data.is_null() {
+            return None;
+        }
+        let state = unsafe { &*(user_data as *const VideoFrameBufferHandlerState) };
+        state.handler.as_ref().as_any().downcast_ref::<T>()
+    }
+
+    /// # Safety
+    /// 同一実体の `VideoFrameBuffer` への参照が存在しないこと。
+    /// 特に callback 側や別 clone から同時に参照されないことを呼び出し側が保証する必要があります。
+    pub unsafe fn as_native_mut<T: VideoFrameBufferHandler + 'static>(&mut self) -> Option<&mut T> {
+        let user_data = unsafe { ffi::webrtc_VideoFrameBuffer_get_user_data(self.raw().as_ptr()) };
+        if user_data.is_null() {
+            return None;
+        }
+        let state = unsafe { &mut *(user_data as *mut VideoFrameBufferHandlerState) };
+        state.handler.as_mut().as_any_mut().downcast_mut::<T>()
+    }
+
+    pub fn as_i420(&self) -> Option<I420Buffer> {
+        let raw_ref = NonNull::new(unsafe {
+            ffi::webrtc_VideoFrameBuffer_cast_to_webrtc_I420Buffer(self.raw().as_ptr())
+        })?;
+        Some(I420Buffer::from_raw_ref(raw_ref))
+    }
+
+    pub fn as_nv12(&self) -> Option<NV12Buffer> {
+        let raw_ref = NonNull::new(unsafe {
+            ffi::webrtc_VideoFrameBuffer_cast_to_webrtc_NV12Buffer(self.raw().as_ptr())
+        })?;
+        Some(NV12Buffer::from_raw_ref(raw_ref))
     }
 
     pub fn to_i420(&mut self) -> Option<I420Buffer> {

--- a/src/api/video_codec_common.rs
+++ b/src/api/video_codec_common.rs
@@ -908,6 +908,16 @@ impl VideoFrame {
     }
 }
 
+impl Clone for VideoFrame {
+    fn clone(&self) -> Self {
+        let raw = unsafe { ffi::webrtc_VideoFrame_copy(self.raw().as_ptr()) };
+        Self {
+            raw_unique: NonNull::new(raw)
+                .expect("BUG: webrtc_VideoFrame_copy が null を返しました"),
+        }
+    }
+}
+
 impl Drop for VideoFrame {
     fn drop(&mut self) {
         unsafe { ffi::webrtc_VideoFrame_unique_delete(self.raw_unique.as_ptr()) };
@@ -954,6 +964,14 @@ impl<'a> VideoFrameRef<'a> {
                 .expect("BUG: webrtc_VideoFrame_video_frame_buffer が null を返しました");
         let raw_ref = ScopedRef::<VideoFrameBufferHandle>::from_raw(buf);
         VideoFrameBuffer { raw_ref }
+    }
+
+    pub fn to_owned(&self) -> VideoFrame {
+        let raw = unsafe { ffi::webrtc_VideoFrame_copy(self.raw.as_ptr()) };
+        VideoFrame {
+            raw_unique: NonNull::new(raw)
+                .expect("BUG: webrtc_VideoFrame_copy が null を返しました"),
+        }
     }
 
     pub(crate) fn as_ptr(&self) -> *mut ffi::webrtc_VideoFrame {

--- a/src/api/video_codec_common.rs
+++ b/src/api/video_codec_common.rs
@@ -1,4 +1,6 @@
-use crate::ref_count::{EncodedImageBufferHandle, I420BufferHandle, VideoFrameBufferHandle};
+use crate::ref_count::{
+    EncodedImageBufferHandle, I420BufferHandle, NV12BufferHandle, VideoFrameBufferHandle,
+};
 use crate::{CxxString, CxxStringRef, Error, MapStringString, Result, ScopedRef, ffi};
 use std::collections::HashMap;
 use std::marker::PhantomData;
@@ -412,6 +414,115 @@ impl I420Buffer {
     }
 
     pub(crate) fn raw(&self) -> NonNull<ffi::webrtc_I420Buffer> {
+        self.raw_ref.raw()
+    }
+}
+
+/// webrtc::NV12Buffer のラッパー。
+pub struct NV12Buffer {
+    raw_ref: ScopedRef<NV12BufferHandle>,
+}
+
+impl NV12Buffer {
+    pub fn new(width: i32, height: i32) -> Self {
+        let raw = NonNull::new(unsafe { ffi::webrtc_NV12Buffer_Create(width, height) })
+            .expect("BUG: webrtc_NV12Buffer_Create returned null");
+        let raw_ref = ScopedRef::<NV12BufferHandle>::from_raw(raw);
+        Self { raw_ref }
+    }
+
+    pub fn width(&self) -> i32 {
+        unsafe { ffi::webrtc_NV12Buffer_width(self.raw().as_ptr()) }
+    }
+
+    pub fn height(&self) -> i32 {
+        unsafe { ffi::webrtc_NV12Buffer_height(self.raw().as_ptr()) }
+    }
+
+    pub fn stride_y(&self) -> i32 {
+        let raw = self.raw();
+        unsafe { ffi::webrtc_NV12Buffer_StrideY(raw.as_ptr()) }
+    }
+
+    pub fn stride_uv(&self) -> i32 {
+        let raw = self.raw();
+        unsafe { ffi::webrtc_NV12Buffer_StrideUV(raw.as_ptr()) }
+    }
+
+    pub fn crop_and_scale_from(
+        &mut self,
+        src: &NV12Buffer,
+        offset_x: i32,
+        offset_y: i32,
+        crop_width: i32,
+        crop_height: i32,
+    ) {
+        let raw = self.raw();
+        let src_raw = src.raw();
+        unsafe {
+            ffi::webrtc_NV12Buffer_CropAndScaleFrom(
+                raw.as_ptr(),
+                src_raw.as_ptr(),
+                offset_x,
+                offset_y,
+                crop_width,
+                crop_height,
+            )
+        };
+    }
+
+    /// Y 平面を参照する。
+    pub fn y_data(&self) -> &[u8] {
+        let raw = self.raw();
+        let ptr = unsafe { ffi::webrtc_NV12Buffer_MutableDataY(raw.as_ptr()) };
+        let stride = unsafe { ffi::webrtc_NV12Buffer_StrideY(raw.as_ptr()) } as usize;
+        let len = stride * self.height() as usize;
+        unsafe { slice::from_raw_parts(ptr, len) }
+    }
+
+    /// Y 平面を可変参照する。
+    pub fn y_data_mut(&mut self) -> &mut [u8] {
+        let raw = self.raw();
+        let ptr = unsafe { ffi::webrtc_NV12Buffer_MutableDataY(raw.as_ptr()) };
+        let stride = unsafe { ffi::webrtc_NV12Buffer_StrideY(raw.as_ptr()) } as usize;
+        let len = stride * self.height() as usize;
+        unsafe { slice::from_raw_parts_mut(ptr, len) }
+    }
+
+    /// UV 平面を参照する。
+    pub fn uv_data(&self) -> &[u8] {
+        let raw = self.raw();
+        let ptr = unsafe { ffi::webrtc_NV12Buffer_MutableDataUV(raw.as_ptr()) };
+        let stride = unsafe { ffi::webrtc_NV12Buffer_StrideUV(raw.as_ptr()) } as usize;
+        let h = (self.height() as usize).div_ceil(2);
+        unsafe { slice::from_raw_parts(ptr, stride * h) }
+    }
+
+    /// UV 平面を可変参照する。
+    pub fn uv_data_mut(&mut self) -> &mut [u8] {
+        let raw = self.raw();
+        let ptr = unsafe { ffi::webrtc_NV12Buffer_MutableDataUV(raw.as_ptr()) };
+        let stride = unsafe { ffi::webrtc_NV12Buffer_StrideUV(raw.as_ptr()) } as usize;
+        let h = (self.height() as usize).div_ceil(2);
+        unsafe { slice::from_raw_parts_mut(ptr, stride * h) }
+    }
+
+    pub fn as_refcounted_ptr(&self) -> *mut ffi::webrtc_NV12Buffer_refcounted {
+        self.raw_ref.as_refcounted_ptr()
+    }
+
+    pub fn cast_to_video_frame_buffer(&self) -> VideoFrameBuffer {
+        let raw_ref = NonNull::new(unsafe {
+            ffi::webrtc_NV12Buffer_refcounted_cast_to_webrtc_VideoFrameBuffer(
+                self.raw_ref.as_refcounted_ptr(),
+            )
+        })
+        .expect("BUG: webrtc_NV12Buffer_refcounted_cast_to_webrtc_VideoFrameBuffer returned null");
+        let raw_ref = ScopedRef::<VideoFrameBufferHandle>::from_raw(raw_ref);
+        VideoFrameBuffer { raw_ref }
+    }
+
+    pub(crate) fn raw(&self) -> NonNull<ffi::webrtc_NV12Buffer> {
         self.raw_ref.raw()
     }
 }

--- a/src/api/video_codec_common.rs
+++ b/src/api/video_codec_common.rs
@@ -325,26 +325,6 @@ impl I420Buffer {
         unsafe { ffi::webrtc_I420Buffer_StrideV(raw.as_ptr()) }
     }
 
-    /// Y 平面を単一値で塗りつぶす。
-    pub fn fill_y(&mut self, value: u8) {
-        let ptr = unsafe { ffi::webrtc_I420Buffer_MutableDataY(self.raw().as_ptr()) };
-        let stride = unsafe { ffi::webrtc_I420Buffer_StrideY(self.raw().as_ptr()) } as usize;
-        let len = stride * self.height() as usize;
-        unsafe { slice::from_raw_parts_mut(ptr, len) }.fill(value);
-    }
-
-    /// U/V 平面を単一値で塗りつぶす。
-    pub fn fill_uv(&mut self, u: u8, v: u8) {
-        let raw = self.raw();
-        let stride_u = unsafe { ffi::webrtc_I420Buffer_StrideU(raw.as_ptr()) } as usize;
-        let stride_v = unsafe { ffi::webrtc_I420Buffer_StrideV(raw.as_ptr()) } as usize;
-        let h = (self.height() as usize).div_ceil(2);
-        let ptr_u = unsafe { ffi::webrtc_I420Buffer_MutableDataU(raw.as_ptr()) };
-        let ptr_v = unsafe { ffi::webrtc_I420Buffer_MutableDataV(raw.as_ptr()) };
-        unsafe { slice::from_raw_parts_mut(ptr_u, stride_u * h) }.fill(u);
-        unsafe { slice::from_raw_parts_mut(ptr_v, stride_v * h) }.fill(v);
-    }
-
     /// 別の I420Buffer からスケールして埋める。
     pub fn scale_from(&mut self, src: &I420Buffer) {
         let raw = self.raw();

--- a/src/api/video_encoder.rs
+++ b/src/api/video_encoder.rs
@@ -1,70 +1,11 @@
 use super::video_codec_common::{
     EncodedImageRef, SdpVideoFormat, SdpVideoFormatRef, VideoCodecRef, VideoCodecStatus,
-    VideoCodecType, VideoFrameRef, VideoFrameTypeVectorRef,
+    VideoCodecType, VideoFrameBufferKind, VideoFrameRef, VideoFrameTypeVectorRef,
 };
 use crate::{CxxString, EnvironmentRef, Result, ffi};
 use std::marker::PhantomData;
 use std::os::raw::c_void;
 use std::ptr::NonNull;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum VideoFrameBufferType {
-    Native,
-    I420,
-    I420A,
-    I422,
-    I444,
-    I010,
-    I210,
-    I410,
-    Nv12,
-    Unknown(i32),
-}
-
-impl VideoFrameBufferType {
-    fn from_raw(value: i32) -> Self {
-        unsafe {
-            if value == ffi::webrtc_VideoFrameBuffer_Type_kNative {
-                Self::Native
-            } else if value == ffi::webrtc_VideoFrameBuffer_Type_kI420 {
-                Self::I420
-            } else if value == ffi::webrtc_VideoFrameBuffer_Type_kI420A {
-                Self::I420A
-            } else if value == ffi::webrtc_VideoFrameBuffer_Type_kI422 {
-                Self::I422
-            } else if value == ffi::webrtc_VideoFrameBuffer_Type_kI444 {
-                Self::I444
-            } else if value == ffi::webrtc_VideoFrameBuffer_Type_kI010 {
-                Self::I010
-            } else if value == ffi::webrtc_VideoFrameBuffer_Type_kI210 {
-                Self::I210
-            } else if value == ffi::webrtc_VideoFrameBuffer_Type_kI410 {
-                Self::I410
-            } else if value == ffi::webrtc_VideoFrameBuffer_Type_kNV12 {
-                Self::Nv12
-            } else {
-                Self::Unknown(value)
-            }
-        }
-    }
-
-    fn to_raw(self) -> i32 {
-        unsafe {
-            match self {
-                Self::Native => ffi::webrtc_VideoFrameBuffer_Type_kNative,
-                Self::I420 => ffi::webrtc_VideoFrameBuffer_Type_kI420,
-                Self::I420A => ffi::webrtc_VideoFrameBuffer_Type_kI420A,
-                Self::I422 => ffi::webrtc_VideoFrameBuffer_Type_kI422,
-                Self::I444 => ffi::webrtc_VideoFrameBuffer_Type_kI444,
-                Self::I010 => ffi::webrtc_VideoFrameBuffer_Type_kI010,
-                Self::I210 => ffi::webrtc_VideoFrameBuffer_Type_kI210,
-                Self::I410 => ffi::webrtc_VideoFrameBuffer_Type_kI410,
-                Self::Nv12 => ffi::webrtc_VideoFrameBuffer_Type_kNV12,
-                Self::Unknown(v) => v,
-            }
-        }
-    }
-}
 
 pub struct VideoEncoderFramerateFractionInlinedVectorRef<'a> {
     raw: NonNull<ffi::webrtc_VideoEncoder_FramerateFraction_inlined_vector>,
@@ -148,12 +89,12 @@ impl<'a> VideoEncoderFramerateFractionInlinedVectorRef<'a> {
 
 unsafe impl<'a> Send for VideoEncoderFramerateFractionInlinedVectorRef<'a> {}
 
-pub struct VideoFrameBufferTypeInlinedVectorRef<'a> {
+pub struct VideoFrameBufferKindInlinedVectorRef<'a> {
     raw: NonNull<ffi::webrtc_VideoFrameBuffer_Type_inlined_vector>,
     _marker: PhantomData<&'a ffi::webrtc_VideoEncoder_EncoderInfo>,
 }
 
-impl<'a> VideoFrameBufferTypeInlinedVectorRef<'a> {
+impl<'a> VideoFrameBufferKindInlinedVectorRef<'a> {
     /// # Safety
     /// `raw` は有効な `webrtc_VideoFrameBuffer_Type_inlined_vector` を指す必要があります。
     pub unsafe fn from_raw(raw: NonNull<ffi::webrtc_VideoFrameBuffer_Type_inlined_vector>) -> Self {
@@ -173,7 +114,7 @@ impl<'a> VideoFrameBufferTypeInlinedVectorRef<'a> {
         self.len() == 0
     }
 
-    pub fn get(&self, index: usize) -> Option<VideoFrameBufferType> {
+    pub fn get(&self, index: usize) -> Option<VideoFrameBufferKind> {
         if index >= self.len() {
             return None;
         }
@@ -182,10 +123,10 @@ impl<'a> VideoFrameBufferTypeInlinedVectorRef<'a> {
         };
         let raw = NonNull::new(raw)?;
         let value = unsafe { ffi::webrtc_VideoFrameBuffer_Type_value(raw.as_ptr()) };
-        Some(VideoFrameBufferType::from_raw(value))
+        Some(VideoFrameBufferKind::from_raw(value))
     }
 
-    pub fn push(&mut self, value: VideoFrameBufferType) {
+    pub fn push(&mut self, value: VideoFrameBufferKind) {
         unsafe {
             ffi::webrtc_VideoFrameBuffer_Type_inlined_vector_push_back_value(
                 self.raw.as_ptr(),
@@ -194,7 +135,7 @@ impl<'a> VideoFrameBufferTypeInlinedVectorRef<'a> {
         };
     }
 
-    pub fn set(&mut self, index: usize, value: VideoFrameBufferType) -> bool {
+    pub fn set(&mut self, index: usize, value: VideoFrameBufferKind) -> bool {
         if index >= self.len() {
             return false;
         }
@@ -218,7 +159,7 @@ impl<'a> VideoFrameBufferTypeInlinedVectorRef<'a> {
     }
 }
 
-unsafe impl<'a> Send for VideoFrameBufferTypeInlinedVectorRef<'a> {}
+unsafe impl<'a> Send for VideoFrameBufferKindInlinedVectorRef<'a> {}
 
 pub struct VideoEncoderQpThresholdsRef<'a> {
     raw: NonNull<ffi::webrtc_VideoEncoder_QpThresholds>,
@@ -915,14 +856,14 @@ impl VideoEncoderEncoderInfo {
         };
     }
 
-    pub fn preferred_pixel_formats(&self) -> VideoFrameBufferTypeInlinedVectorRef<'_> {
+    pub fn preferred_pixel_formats(&self) -> VideoFrameBufferKindInlinedVectorRef<'_> {
         let raw = unsafe {
             ffi::webrtc_VideoEncoder_EncoderInfo_get_preferred_pixel_formats(self.as_ptr())
         };
         let raw = NonNull::new(raw).expect(
             "BUG: webrtc_VideoEncoder_EncoderInfo_get_preferred_pixel_formats が null を返しました",
         );
-        unsafe { VideoFrameBufferTypeInlinedVectorRef::from_raw(raw) }
+        unsafe { VideoFrameBufferKindInlinedVectorRef::from_raw(raw) }
     }
 
     pub fn is_qp_trusted(&self) -> Option<bool> {

--- a/src/libyuv.rs
+++ b/src/libyuv.rs
@@ -1,4 +1,4 @@
-use crate::{I420Buffer, ffi};
+use crate::{I420Buffer, NV12Buffer, ffi};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LibyuvFourcc {
@@ -52,19 +52,18 @@ pub fn convert_from_i420(src: &I420Buffer, fourcc: LibyuvFourcc) -> Option<Vec<u
 
 /// `libyuv::I420ToNV12` を呼び出して、I420 を NV12 へ変換する。
 /// 変換に失敗した場合は `None` を返す。
-pub fn i420_to_nv12(src: &I420Buffer) -> Option<Vec<u8>> {
+pub fn i420_to_nv12(src: &I420Buffer) -> Option<NV12Buffer> {
     let width = src.width();
     let height = src.height();
     if width <= 0 || height <= 0 {
         return None;
     }
 
-    let width = width as usize;
-    let height = height as usize;
-    let y_size = width.checked_mul(height)?;
-    let uv_size = width.checked_mul(height.div_ceil(2))?;
-    let mut dst = vec![0u8; y_size.checked_add(uv_size)?];
-    let (dst_y, dst_uv) = dst.split_at_mut(y_size);
+    let mut dst = NV12Buffer::new(width, height);
+    let dst_stride_y = dst.stride_y();
+    let dst_stride_uv = dst.stride_uv();
+    let dst_y = dst.y_data_mut().as_mut_ptr();
+    let dst_uv = dst.uv_data_mut().as_mut_ptr();
 
     let ret = unsafe {
         ffi::libyuv_I420ToNV12(
@@ -74,12 +73,12 @@ pub fn i420_to_nv12(src: &I420Buffer) -> Option<Vec<u8>> {
             src.stride_u(),
             src.v_data().as_ptr(),
             src.stride_v(),
-            dst_y.as_mut_ptr(),
-            width as i32,
-            dst_uv.as_mut_ptr(),
-            width as i32,
-            width as i32,
-            height as i32,
+            dst_y,
+            dst_stride_y,
+            dst_uv,
+            dst_stride_uv,
+            width,
+            height,
         )
     };
     if ret != 0 {
@@ -96,18 +95,25 @@ pub fn abgr_to_i420(src_abgr: &[u8], width: i32, height: i32) -> Option<I420Buff
     if src_abgr.len() < needed {
         return None;
     }
-    let buf = I420Buffer::new(width, height);
-    let raw = buf.raw().as_ptr();
+
+    let mut buf = I420Buffer::new(width, height);
+    let dst_stride_y = buf.stride_y();
+    let dst_stride_u = buf.stride_u();
+    let dst_stride_v = buf.stride_v();
+    let dst_y = buf.y_data_mut().as_mut_ptr();
+    let dst_u = buf.u_data_mut().as_mut_ptr();
+    let dst_v = buf.v_data_mut().as_mut_ptr();
+
     let ret = unsafe {
         ffi::libyuv_ABGRToI420(
             src_abgr.as_ptr(),
             stride as i32,
-            ffi::webrtc_I420Buffer_MutableDataY(raw),
-            ffi::webrtc_I420Buffer_StrideY(raw),
-            ffi::webrtc_I420Buffer_MutableDataU(raw),
-            ffi::webrtc_I420Buffer_StrideU(raw),
-            ffi::webrtc_I420Buffer_MutableDataV(raw),
-            ffi::webrtc_I420Buffer_StrideV(raw),
+            dst_y,
+            dst_stride_y,
+            dst_u,
+            dst_stride_u,
+            dst_v,
+            dst_stride_v,
             width,
             height,
         )
@@ -120,31 +126,33 @@ pub fn abgr_to_i420(src_abgr: &[u8], width: i32, height: i32) -> Option<I420Buff
 
 /// `libyuv::NV12ToI420` を呼び出して、NV12 から I420 へ変換する。
 /// 変換に失敗した場合は `None` を返す。
-pub fn nv12_to_i420(
-    src_y: &[u8],
-    src_stride_y: i32,
-    src_uv: &[u8],
-    src_stride_uv: i32,
-    width: i32,
-    height: i32,
-) -> Option<I420Buffer> {
+pub fn nv12_to_i420(src: &NV12Buffer) -> Option<I420Buffer> {
+    let width = src.width();
+    let height = src.height();
     if width <= 0 || height <= 0 {
         return None;
     }
-    let buf = I420Buffer::new(width, height);
-    let raw = buf.raw().as_ptr();
+
+    let mut buf = I420Buffer::new(width, height);
+    let dst_stride_y = buf.stride_y();
+    let dst_stride_u = buf.stride_u();
+    let dst_stride_v = buf.stride_v();
+    let dst_y = buf.y_data_mut().as_mut_ptr();
+    let dst_u = buf.u_data_mut().as_mut_ptr();
+    let dst_v = buf.v_data_mut().as_mut_ptr();
+
     let ret = unsafe {
         ffi::libyuv_NV12ToI420(
-            src_y.as_ptr(),
-            src_stride_y,
-            src_uv.as_ptr(),
-            src_stride_uv,
-            ffi::webrtc_I420Buffer_MutableDataY(raw),
-            ffi::webrtc_I420Buffer_StrideY(raw),
-            ffi::webrtc_I420Buffer_MutableDataU(raw),
-            ffi::webrtc_I420Buffer_StrideU(raw),
-            ffi::webrtc_I420Buffer_MutableDataV(raw),
-            ffi::webrtc_I420Buffer_StrideV(raw),
+            src.y_data().as_ptr(),
+            src.stride_y(),
+            src.uv_data().as_ptr(),
+            src.stride_uv(),
+            dst_y,
+            dst_stride_y,
+            dst_u,
+            dst_stride_u,
+            dst_v,
+            dst_stride_v,
             width,
             height,
         )
@@ -166,18 +174,25 @@ pub fn yuy2_to_i420(
     if width <= 0 || height <= 0 {
         return None;
     }
-    let buf = I420Buffer::new(width, height);
-    let raw = buf.raw().as_ptr();
+
+    let mut buf = I420Buffer::new(width, height);
+    let dst_stride_y = buf.stride_y();
+    let dst_stride_u = buf.stride_u();
+    let dst_stride_v = buf.stride_v();
+    let dst_y = buf.y_data_mut().as_mut_ptr();
+    let dst_u = buf.u_data_mut().as_mut_ptr();
+    let dst_v = buf.v_data_mut().as_mut_ptr();
+
     let ret = unsafe {
         ffi::libyuv_YUY2ToI420(
             src_yuy2.as_ptr(),
             src_stride,
-            ffi::webrtc_I420Buffer_MutableDataY(raw),
-            ffi::webrtc_I420Buffer_StrideY(raw),
-            ffi::webrtc_I420Buffer_MutableDataU(raw),
-            ffi::webrtc_I420Buffer_StrideU(raw),
-            ffi::webrtc_I420Buffer_MutableDataV(raw),
-            ffi::webrtc_I420Buffer_StrideV(raw),
+            dst_y,
+            dst_stride_y,
+            dst_u,
+            dst_stride_u,
+            dst_v,
+            dst_stride_v,
             width,
             height,
         )

--- a/src/ref_count.rs
+++ b/src/ref_count.rs
@@ -169,6 +169,22 @@ impl RefCountedHandle for I420BufferHandle {
     }
 }
 
+pub(crate) struct VideoFrameBufferHandle;
+impl RefCountedHandle for VideoFrameBufferHandle {
+    type Refcounted = ffi::webrtc_VideoFrameBuffer_refcounted;
+    type Raw = ffi::webrtc_VideoFrameBuffer;
+
+    unsafe fn get(raw_ref: *mut Self::Refcounted) -> *mut Self::Raw {
+        unsafe { ffi::webrtc_VideoFrameBuffer_refcounted_get(raw_ref) }
+    }
+    unsafe fn add_ref(raw: *mut Self::Raw) {
+        unsafe { ffi::webrtc_VideoFrameBuffer_AddRef(raw) };
+    }
+    unsafe fn release(raw: *mut Self::Raw) {
+        unsafe { ffi::webrtc_VideoFrameBuffer_Release(raw) };
+    }
+}
+
 pub(crate) struct EncodedImageBufferHandle;
 impl RefCountedHandle for EncodedImageBufferHandle {
     type Refcounted = ffi::webrtc_EncodedImageBuffer_refcounted;

--- a/src/ref_count.rs
+++ b/src/ref_count.rs
@@ -169,6 +169,22 @@ impl RefCountedHandle for I420BufferHandle {
     }
 }
 
+pub(crate) struct NV12BufferHandle;
+impl RefCountedHandle for NV12BufferHandle {
+    type Refcounted = ffi::webrtc_NV12Buffer_refcounted;
+    type Raw = ffi::webrtc_NV12Buffer;
+
+    unsafe fn get(raw_ref: *mut Self::Refcounted) -> *mut Self::Raw {
+        unsafe { ffi::webrtc_NV12Buffer_refcounted_get(raw_ref) }
+    }
+    unsafe fn add_ref(raw: *mut Self::Raw) {
+        unsafe { ffi::webrtc_NV12Buffer_AddRef(raw) };
+    }
+    unsafe fn release(raw: *mut Self::Raw) {
+        unsafe { ffi::webrtc_NV12Buffer_Release(raw) };
+    }
+}
+
 pub(crate) struct VideoFrameBufferHandle;
 impl RefCountedHandle for VideoFrameBufferHandle {
     type Refcounted = ffi::webrtc_VideoFrameBuffer_refcounted;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -243,6 +243,54 @@ fn i420_buffer_mutable_planes_and_video_frame_rtp_timestamp() {
 }
 
 #[test]
+fn video_frame_clone() {
+    let mut buf = I420Buffer::new(4, 4);
+    buf.y_data_mut().fill(0x44);
+    buf.u_data_mut().fill(0x55);
+    buf.v_data_mut().fill(0x66);
+
+    let frame_buffer = buf.cast_to_video_frame_buffer();
+    let frame = VideoFrame::from_buffer(&frame_buffer, 11111, 22222);
+    let cloned = frame.clone();
+
+    assert_eq!(cloned.width(), frame.width());
+    assert_eq!(cloned.height(), frame.height());
+    assert_eq!(cloned.timestamp_us(), frame.timestamp_us());
+    assert_eq!(cloned.rtp_timestamp(), frame.rtp_timestamp());
+    assert_ne!(cloned.as_ref().as_ptr(), frame.as_ref().as_ptr());
+
+    let mut copied = cloned.buffer();
+    let copied = copied
+        .to_i420()
+        .expect("clone した VideoFrame の buffer 変換に失敗しました");
+    assert_eq!(copied.y_data()[0], 0x44);
+}
+
+#[test]
+fn video_frame_ref_to_owned() {
+    let mut buf = I420Buffer::new(4, 4);
+    buf.y_data_mut().fill(0x77);
+    buf.u_data_mut().fill(0x88);
+    buf.v_data_mut().fill(0x99);
+
+    let frame_buffer = buf.cast_to_video_frame_buffer();
+    let frame = VideoFrame::from_buffer(&frame_buffer, 33333, 44444);
+    let copied = frame.as_ref().to_owned();
+
+    assert_eq!(copied.width(), frame.width());
+    assert_eq!(copied.height(), frame.height());
+    assert_eq!(copied.timestamp_us(), frame.timestamp_us());
+    assert_eq!(copied.rtp_timestamp(), frame.rtp_timestamp());
+    assert_ne!(copied.as_ref().as_ptr(), frame.as_ref().as_ptr());
+
+    let mut copied_buffer = copied.buffer();
+    let copied_i420 = copied_buffer
+        .to_i420()
+        .expect("to_owned した VideoFrame の buffer 変換に失敗しました");
+    assert_eq!(copied_i420.y_data()[0], 0x77);
+}
+
+#[test]
 fn i420_buffer_chroma_dimensions_for_odd_size() {
     let width = 5;
     let height = 3;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -610,6 +610,191 @@ fn video_frame_buffer_handler_crop_and_scale_fallback() {
 }
 
 #[test]
+fn video_frame_buffer_as_native_roundtrip() {
+    struct DowncastBufferHandler {
+        value: u8,
+    }
+
+    impl VideoFrameBufferHandler for DowncastBufferHandler {
+        fn width(&mut self) -> i32 {
+            2
+        }
+
+        fn height(&mut self) -> i32 {
+            2
+        }
+
+        fn to_i420(&mut self) -> Option<I420Buffer> {
+            let mut buffer = I420Buffer::new(2, 2);
+            buffer.y_data_mut().fill(self.value);
+            buffer.u_data_mut().fill(0x01);
+            buffer.v_data_mut().fill(0x02);
+            Some(buffer)
+        }
+    }
+
+    let mut buffer =
+        VideoFrameBuffer::new_with_handler(Box::new(DowncastBufferHandler { value: 7 }));
+    // Safety: このテストでは同一実体への同時アクセスを行いません。
+    let handler = unsafe { buffer.as_native_ref::<DowncastBufferHandler>() }
+        .expect("as_native_ref が失敗しました");
+    assert_eq!(handler.value, 7);
+
+    // Safety: このテストでは同一実体への同時アクセスを行いません。
+    let handler = unsafe { buffer.as_native_mut::<DowncastBufferHandler>() }
+        .expect("as_native_mut が失敗しました");
+    handler.value = 9;
+
+    // Safety: このテストでは同一実体への同時アクセスを行いません。
+    let handler = unsafe { buffer.as_native_ref::<DowncastBufferHandler>() }
+        .expect("as_native_ref が失敗しました");
+    assert_eq!(handler.value, 9);
+
+    let i420 = buffer
+        .to_i420()
+        .expect("VideoFrameBuffer の I420 変換に失敗しました");
+    assert_eq!(i420.y_data()[0], 9);
+}
+
+#[test]
+fn video_frame_buffer_as_native_clone_and_frame_buffer() {
+    struct DowncastBufferHandler {
+        value: u8,
+    }
+
+    impl VideoFrameBufferHandler for DowncastBufferHandler {
+        fn width(&mut self) -> i32 {
+            2
+        }
+
+        fn height(&mut self) -> i32 {
+            2
+        }
+
+        fn to_i420(&mut self) -> Option<I420Buffer> {
+            let mut buffer = I420Buffer::new(2, 2);
+            buffer.y_data_mut().fill(self.value);
+            buffer.u_data_mut().fill(0x11);
+            buffer.v_data_mut().fill(0x22);
+            Some(buffer)
+        }
+    }
+
+    let mut buffer =
+        VideoFrameBuffer::new_with_handler(Box::new(DowncastBufferHandler { value: 3 }));
+    // Safety: このテストでは同一実体への同時アクセスを行いません。
+    unsafe { buffer.as_native_mut::<DowncastBufferHandler>() }
+        .expect("as_native_mut が失敗しました")
+        .value = 5;
+
+    let cloned = buffer.clone();
+    // Safety: このテストでは同一実体への同時アクセスを行いません。
+    let cloned_handler = unsafe { cloned.as_native_ref::<DowncastBufferHandler>() }
+        .expect("clone からの as_native_ref が失敗しました");
+    assert_eq!(cloned_handler.value, 5);
+
+    let frame = VideoFrame::from_buffer(&buffer, 10, 20);
+    let frame_buffer = frame.buffer();
+    // Safety: このテストでは同一実体への同時アクセスを行いません。
+    let frame_handler = unsafe { frame_buffer.as_native_ref::<DowncastBufferHandler>() }
+        .expect("VideoFrame::buffer からの as_native_ref が失敗しました");
+    assert_eq!(frame_handler.value, 5);
+}
+
+#[test]
+fn video_frame_buffer_as_native_returns_none_for_builtin_buffers() {
+    struct NativeBufferHandler;
+
+    impl VideoFrameBufferHandler for NativeBufferHandler {
+        fn width(&mut self) -> i32 {
+            1
+        }
+
+        fn height(&mut self) -> i32 {
+            1
+        }
+
+        fn to_i420(&mut self) -> Option<I420Buffer> {
+            Some(I420Buffer::new(1, 1))
+        }
+    }
+
+    let i420 = I420Buffer::new(2, 2);
+    let mut i420_frame_buffer = i420.cast_to_video_frame_buffer();
+    // Safety: 参照を取り出すだけで、同時アクセスは行いません。
+    assert!(unsafe {
+        i420_frame_buffer
+            .as_native_ref::<NativeBufferHandler>()
+            .is_none()
+    });
+    // Safety: 参照を取り出すだけで、同時アクセスは行いません。
+    assert!(unsafe {
+        i420_frame_buffer
+            .as_native_mut::<NativeBufferHandler>()
+            .is_none()
+    });
+
+    let nv12 = NV12Buffer::new(2, 2);
+    let mut nv12_frame_buffer = nv12.cast_to_video_frame_buffer();
+    // Safety: 参照を取り出すだけで、同時アクセスは行いません。
+    assert!(unsafe {
+        nv12_frame_buffer
+            .as_native_ref::<NativeBufferHandler>()
+            .is_none()
+    });
+    // Safety: 参照を取り出すだけで、同時アクセスは行いません。
+    assert!(unsafe {
+        nv12_frame_buffer
+            .as_native_mut::<NativeBufferHandler>()
+            .is_none()
+    });
+}
+
+#[test]
+fn video_frame_buffer_as_i420_and_as_nv12() {
+    let i420 = I420Buffer::new(2, 2);
+    let i420_frame_buffer = i420.cast_to_video_frame_buffer();
+    let i420_view = i420_frame_buffer
+        .as_i420()
+        .expect("as_i420 failed on I420 buffer");
+    assert_eq!(i420_view.width(), 2);
+    assert_eq!(i420_view.height(), 2);
+    assert!(i420_frame_buffer.as_nv12().is_none());
+
+    let nv12 = NV12Buffer::new(2, 2);
+    let nv12_frame_buffer = nv12.cast_to_video_frame_buffer();
+    let nv12_view = nv12_frame_buffer
+        .as_nv12()
+        .expect("as_nv12 failed on NV12 buffer");
+    assert_eq!(nv12_view.width(), 2);
+    assert_eq!(nv12_view.height(), 2);
+    assert!(nv12_frame_buffer.as_i420().is_none());
+}
+
+#[test]
+fn video_frame_buffer_as_i420_and_as_nv12_return_none_for_native() {
+    struct NativeBufferHandler;
+
+    impl VideoFrameBufferHandler for NativeBufferHandler {
+        fn width(&mut self) -> i32 {
+            2
+        }
+
+        fn height(&mut self) -> i32 {
+            2
+        }
+
+        fn to_i420(&mut self) -> Option<I420Buffer> {
+            Some(I420Buffer::new(2, 2))
+        }
+    }
+
+    let frame_buffer = VideoFrameBuffer::new_with_handler(Box::new(NativeBufferHandler));
+    assert!(frame_buffer.as_i420().is_none());
+    assert!(frame_buffer.as_nv12().is_none());
+}
+
+#[test]
 fn abgr_to_i420_conversion() {
     // 2x2 ピクセル、ABGR = 0xff804020 (B=0x20, G=0x40, R=0x80, A=0xff)
     let pixel = [0x20u8, 0x40, 0x80, 0xff];

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,6 +3,7 @@ use std::ptr::NonNull;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
+    Mutex,
 };
 use std::time::Duration;
 
@@ -351,6 +352,124 @@ fn video_frame_buffer_handler_to_i420_none() {
     let frame = VideoFrame::from_buffer(&buffer, 100, 0);
     let mut frame_buffer = frame.buffer();
     assert!(frame_buffer.to_i420().is_none());
+}
+
+#[test]
+fn video_frame_buffer_crop_and_scale_from_i420_buffer() {
+    let mut src = I420Buffer::new(4, 4);
+    src.y_data_mut().fill(0x10);
+    src.u_data_mut().fill(0x20);
+    src.v_data_mut().fill(0x30);
+
+    let mut frame_buffer = src.cast_to_video_frame_buffer();
+    let scaled = frame_buffer
+        .scale(2, 2)
+        .expect("VideoFrameBuffer::scale の変換に失敗しました");
+    assert_eq!(scaled.width(), 2);
+    assert_eq!(scaled.height(), 2);
+
+    let mut frame_buffer = src.cast_to_video_frame_buffer();
+    let cropped_scaled = frame_buffer
+        .crop_and_scale(1, 1, 2, 2, 3, 3)
+        .expect("VideoFrameBuffer::crop_and_scale の変換に失敗しました");
+    assert_eq!(cropped_scaled.width(), 3);
+    assert_eq!(cropped_scaled.height(), 3);
+}
+
+#[test]
+fn video_frame_buffer_handler_crop_and_scale_callback() {
+    struct CropAndScaleBufferHandler {
+        called: Arc<AtomicBool>,
+        args: Arc<Mutex<Option<(i32, i32, i32, i32, i32, i32)>>>,
+    }
+
+    impl VideoFrameBufferHandler for CropAndScaleBufferHandler {
+        fn width(&mut self) -> i32 {
+            8
+        }
+
+        fn height(&mut self) -> i32 {
+            8
+        }
+
+        fn to_i420(&mut self) -> Option<I420Buffer> {
+            Some(I420Buffer::new(8, 8))
+        }
+
+        fn crop_and_scale(
+            &mut self,
+            offset_x: i32,
+            offset_y: i32,
+            crop_width: i32,
+            crop_height: i32,
+            scaled_width: i32,
+            scaled_height: i32,
+        ) -> Option<VideoFrameBuffer> {
+            self.called.store(true, Ordering::SeqCst);
+            *self.args.lock().expect("args のロックに失敗しました") = Some((
+                offset_x,
+                offset_y,
+                crop_width,
+                crop_height,
+                scaled_width,
+                scaled_height,
+            ));
+            Some(
+                I420Buffer::new(scaled_width, scaled_height)
+                    .cast_to_video_frame_buffer(),
+            )
+        }
+    }
+
+    let called = Arc::new(AtomicBool::new(false));
+    let args = Arc::new(Mutex::new(None));
+    let handler = CropAndScaleBufferHandler {
+        called: Arc::clone(&called),
+        args: Arc::clone(&args),
+    };
+    let mut buffer = VideoFrameBuffer::new_with_handler(Box::new(handler));
+
+    let scaled = buffer
+        .crop_and_scale(1, 2, 3, 4, 5, 6)
+        .expect("VideoFrameBufferHandler::crop_and_scale の実行に失敗しました");
+
+    assert!(called.load(Ordering::SeqCst));
+    assert_eq!(
+        *args.lock().expect("args のロックに失敗しました"),
+        Some((1, 2, 3, 4, 5, 6))
+    );
+    assert_eq!(scaled.width(), 5);
+    assert_eq!(scaled.height(), 6);
+}
+
+#[test]
+fn video_frame_buffer_handler_crop_and_scale_fallback() {
+    struct NoCropAndScaleBufferHandler;
+
+    impl VideoFrameBufferHandler for NoCropAndScaleBufferHandler {
+        fn width(&mut self) -> i32 {
+            4
+        }
+
+        fn height(&mut self) -> i32 {
+            4
+        }
+
+        fn to_i420(&mut self) -> Option<I420Buffer> {
+            let mut buffer = I420Buffer::new(4, 4);
+            buffer.y_data_mut().fill(0x55);
+            buffer.u_data_mut().fill(0x66);
+            buffer.v_data_mut().fill(0x77);
+            Some(buffer)
+        }
+    }
+
+    let mut buffer = VideoFrameBuffer::new_with_handler(Box::new(NoCropAndScaleBufferHandler));
+    let scaled = buffer
+        .scale(2, 2)
+        .expect("VideoFrameBuffer::scale のフォールバックに失敗しました");
+    assert_eq!(scaled.width(), 2);
+    assert_eq!(scaled.height(), 2);
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -208,8 +208,9 @@ fn scalability_mode_round_trip() {
 #[test]
 fn i420_buffer_and_video_frame() {
     let mut buf = I420Buffer::new(4, 4);
-    buf.fill_y(0x10);
-    buf.fill_uv(0x80, 0x90);
+    buf.y_data_mut().fill(0x10);
+    buf.u_data_mut().fill(0x80);
+    buf.v_data_mut().fill(0x90);
 
     let frame_buffer = buf.cast_to_video_frame_buffer();
     let frame = VideoFrame::from_buffer(&frame_buffer, 12345, 0);
@@ -256,8 +257,9 @@ fn video_frame_buffer_handler_native_roundtrip() {
 
         fn to_i420(&mut self) -> Option<I420Buffer> {
             let mut buffer = I420Buffer::new(2, 2);
-            buffer.fill_y(0x12);
-            buffer.fill_uv(0x34, 0x56);
+            buffer.y_data_mut().fill(0x12);
+            buffer.u_data_mut().fill(0x34);
+            buffer.v_data_mut().fill(0x56);
             Some(buffer)
         }
     }
@@ -305,8 +307,9 @@ fn video_frame_buffer_handler_custom_type_roundtrip() {
 
         fn to_i420(&mut self) -> Option<I420Buffer> {
             let mut buffer = I420Buffer::new(2, 2);
-            buffer.fill_y(0x77);
-            buffer.fill_uv(0x88, 0x99);
+            buffer.y_data_mut().fill(0x77);
+            buffer.u_data_mut().fill(0x88);
+            buffer.v_data_mut().fill(0x99);
             Some(buffer)
         }
     }
@@ -368,8 +371,9 @@ fn abgr_to_i420_conversion() {
 #[test]
 fn convert_from_i420_argb_conversion() {
     let mut src = I420Buffer::new(2, 2);
-    src.fill_y(0x30);
-    src.fill_uv(0x80, 0x80);
+    src.y_data_mut().fill(0x30);
+    src.u_data_mut().fill(0x80);
+    src.v_data_mut().fill(0x80);
 
     let dst = convert_from_i420(&src, LibyuvFourcc::Argb)
         .expect("convert_from_i420(Argb) の変換に失敗しました");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -652,10 +652,7 @@ fn i420_to_nv12_round_trip() {
     }
 
     let nv12 = i420_to_nv12(&src).expect("i420_to_nv12 の変換に失敗しました");
-    let y_size = (width * height) as usize;
-    let (y, uv) = nv12.split_at(y_size);
-    let restored = nv12_to_i420(y, width, uv, width, width, height)
-        .expect("nv12_to_i420 の逆変換に失敗しました");
+    let restored = nv12_to_i420(&nv12).expect("nv12_to_i420 の逆変換に失敗しました");
 
     assert_eq!(src.y_data(), restored.y_data());
     assert_eq!(src.u_data(), restored.u_data());

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -388,11 +388,11 @@ fn video_frame_buffer_handler_native_roundtrip() {
     struct NativeBufferHandler;
 
     impl VideoFrameBufferHandler for NativeBufferHandler {
-        fn width(&mut self) -> i32 {
+        fn width(&self) -> i32 {
             2
         }
 
-        fn height(&mut self) -> i32 {
+        fn height(&self) -> i32 {
             2
         }
 
@@ -434,15 +434,15 @@ fn video_frame_buffer_handler_custom_type_roundtrip() {
     struct I420TypeBufferHandler;
 
     impl VideoFrameBufferHandler for I420TypeBufferHandler {
-        fn kind(&mut self) -> VideoFrameBufferKind {
+        fn kind(&self) -> VideoFrameBufferKind {
             VideoFrameBufferKind::I420
         }
 
-        fn width(&mut self) -> i32 {
+        fn width(&self) -> i32 {
             2
         }
 
-        fn height(&mut self) -> i32 {
+        fn height(&self) -> i32 {
             2
         }
 
@@ -473,11 +473,11 @@ fn video_frame_buffer_handler_to_i420_none() {
     struct NoI420BufferHandler;
 
     impl VideoFrameBufferHandler for NoI420BufferHandler {
-        fn width(&mut self) -> i32 {
+        fn width(&self) -> i32 {
             2
         }
 
-        fn height(&mut self) -> i32 {
+        fn height(&self) -> i32 {
             2
         }
 
@@ -524,11 +524,11 @@ fn video_frame_buffer_handler_crop_and_scale_callback() {
     }
 
     impl VideoFrameBufferHandler for CropAndScaleBufferHandler {
-        fn width(&mut self) -> i32 {
+        fn width(&self) -> i32 {
             8
         }
 
-        fn height(&mut self) -> i32 {
+        fn height(&self) -> i32 {
             8
         }
 
@@ -584,11 +584,11 @@ fn video_frame_buffer_handler_crop_and_scale_fallback() {
     struct NoCropAndScaleBufferHandler;
 
     impl VideoFrameBufferHandler for NoCropAndScaleBufferHandler {
-        fn width(&mut self) -> i32 {
+        fn width(&self) -> i32 {
             4
         }
 
-        fn height(&mut self) -> i32 {
+        fn height(&self) -> i32 {
             4
         }
 
@@ -616,11 +616,11 @@ fn video_frame_buffer_as_native_roundtrip() {
     }
 
     impl VideoFrameBufferHandler for DowncastBufferHandler {
-        fn width(&mut self) -> i32 {
+        fn width(&self) -> i32 {
             2
         }
 
-        fn height(&mut self) -> i32 {
+        fn height(&self) -> i32 {
             2
         }
 
@@ -663,11 +663,11 @@ fn video_frame_buffer_as_native_clone_and_frame_buffer() {
     }
 
     impl VideoFrameBufferHandler for DowncastBufferHandler {
-        fn width(&mut self) -> i32 {
+        fn width(&self) -> i32 {
             2
         }
 
-        fn height(&mut self) -> i32 {
+        fn height(&self) -> i32 {
             2
         }
 
@@ -706,11 +706,11 @@ fn video_frame_buffer_as_native_returns_none_for_builtin_buffers() {
     struct NativeBufferHandler;
 
     impl VideoFrameBufferHandler for NativeBufferHandler {
-        fn width(&mut self) -> i32 {
+        fn width(&self) -> i32 {
             1
         }
 
-        fn height(&mut self) -> i32 {
+        fn height(&self) -> i32 {
             1
         }
 
@@ -776,11 +776,11 @@ fn video_frame_buffer_as_i420_and_as_nv12_return_none_for_native() {
     struct NativeBufferHandler;
 
     impl VideoFrameBufferHandler for NativeBufferHandler {
-        fn width(&mut self) -> i32 {
+        fn width(&self) -> i32 {
             2
         }
 
-        fn height(&mut self) -> i32 {
+        fn height(&self) -> i32 {
             2
         }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -211,12 +211,16 @@ fn i420_buffer_and_video_frame() {
     buf.fill_y(0x10);
     buf.fill_uv(0x80, 0x90);
 
-    let frame = VideoFrame::from_i420(&buf, 12345, 0);
+    let frame_buffer = buf.cast_to_video_frame_buffer();
+    let frame = VideoFrame::from_buffer(&frame_buffer, 12345, 0);
     assert_eq!(frame.width(), 4);
     assert_eq!(frame.height(), 4);
     assert_eq!(frame.timestamp_us(), 12345);
 
-    let copied = frame.buffer();
+    let mut copied = frame.buffer();
+    let copied = copied
+        .to_i420()
+        .expect("VideoFrameBuffer から I420Buffer への変換に失敗しました");
     assert_eq!(copied.y_data()[0], 0x10);
 }
 
@@ -230,10 +234,120 @@ fn i420_buffer_mutable_planes_and_video_frame_rtp_timestamp() {
     assert!(buf.u_data().iter().all(|&v| v == 0x22));
     assert!(buf.v_data().iter().all(|&v| v == 0x33));
 
-    let frame = VideoFrame::from_i420(&buf, 12345, 67890);
+    let frame_buffer = buf.cast_to_video_frame_buffer();
+    let frame = VideoFrame::from_buffer(&frame_buffer, 12345, 67890);
     assert_eq!(frame.timestamp_us(), 12345);
     assert_eq!(frame.rtp_timestamp(), 67890);
     assert_eq!(frame.as_ref().rtp_timestamp(), 67890);
+}
+
+#[test]
+fn video_frame_buffer_handler_native_roundtrip() {
+    struct NativeBufferHandler;
+
+    impl VideoFrameBufferHandler for NativeBufferHandler {
+        fn width(&mut self) -> i32 {
+            2
+        }
+
+        fn height(&mut self) -> i32 {
+            2
+        }
+
+        fn to_i420(&mut self) -> Option<I420Buffer> {
+            let mut buffer = I420Buffer::new(2, 2);
+            buffer.fill_y(0x12);
+            buffer.fill_uv(0x34, 0x56);
+            Some(buffer)
+        }
+    }
+
+    let mut buffer = VideoFrameBuffer::new_with_handler(Box::new(NativeBufferHandler));
+    assert_eq!(buffer.kind(), VideoFrameBufferKind::Native);
+    assert_eq!(buffer.width(), 2);
+    assert_eq!(buffer.height(), 2);
+
+    let converted = buffer
+        .to_i420()
+        .expect("VideoFrameBufferHandler の ToI420 が None になりました");
+    assert_eq!(converted.y_data()[0], 0x12);
+
+    let frame = VideoFrame::from_buffer(&buffer, 12345, 67890);
+    assert_eq!(frame.width(), 2);
+    assert_eq!(frame.height(), 2);
+    assert_eq!(frame.timestamp_us(), 12345);
+    assert_eq!(frame.rtp_timestamp(), 67890);
+
+    let mut frame_buffer = frame.buffer();
+    assert_eq!(frame_buffer.kind(), VideoFrameBufferKind::Native);
+    let frame_i420 = frame_buffer
+        .to_i420()
+        .expect("VideoFrame の VideoFrameBuffer から I420 変換に失敗しました");
+    assert_eq!(frame_i420.y_data()[0], 0x12);
+}
+
+#[test]
+fn video_frame_buffer_handler_custom_type_roundtrip() {
+    struct I420TypeBufferHandler;
+
+    impl VideoFrameBufferHandler for I420TypeBufferHandler {
+        fn kind(&mut self) -> VideoFrameBufferKind {
+            VideoFrameBufferKind::I420
+        }
+
+        fn width(&mut self) -> i32 {
+            2
+        }
+
+        fn height(&mut self) -> i32 {
+            2
+        }
+
+        fn to_i420(&mut self) -> Option<I420Buffer> {
+            let mut buffer = I420Buffer::new(2, 2);
+            buffer.fill_y(0x77);
+            buffer.fill_uv(0x88, 0x99);
+            Some(buffer)
+        }
+    }
+
+    let buffer = VideoFrameBuffer::new_with_handler(Box::new(I420TypeBufferHandler));
+    assert_eq!(buffer.kind(), VideoFrameBufferKind::I420);
+
+    let frame = VideoFrame::from_buffer(&buffer, 222, 333);
+    let mut frame_buffer = frame.buffer();
+    assert_eq!(frame_buffer.kind(), VideoFrameBufferKind::I420);
+
+    let converted = frame_buffer
+        .to_i420()
+        .expect("VideoFrameBuffer の I420 変換に失敗しました");
+    assert_eq!(converted.y_data()[0], 0x77);
+}
+
+#[test]
+fn video_frame_buffer_handler_to_i420_none() {
+    struct NoI420BufferHandler;
+
+    impl VideoFrameBufferHandler for NoI420BufferHandler {
+        fn width(&mut self) -> i32 {
+            2
+        }
+
+        fn height(&mut self) -> i32 {
+            2
+        }
+
+        fn to_i420(&mut self) -> Option<I420Buffer> {
+            None
+        }
+    }
+
+    let mut buffer = VideoFrameBuffer::new_with_handler(Box::new(NoI420BufferHandler));
+    assert!(buffer.to_i420().is_none());
+
+    let frame = VideoFrame::from_buffer(&buffer, 100, 0);
+    let mut frame_buffer = frame.buffer();
+    assert!(frame_buffer.to_i420().is_none());
 }
 
 #[test]
@@ -509,7 +623,8 @@ fn adapted_video_track_source() {
     assert!(adapted.size.adapted_height >= 0);
 
     let buf = I420Buffer::new(2, 2);
-    let frame = VideoFrame::from_i420(&buf, 2_000_000, 0);
+    let frame_buffer = buf.cast_to_video_frame_buffer();
+    let frame = VideoFrame::from_buffer(&frame_buffer, 2_000_000, 0);
     src.on_frame(&frame);
 }
 
@@ -1081,7 +1196,8 @@ fn video_track_and_transceiver_with_track() {
         .expect("VideoTrack の生成に失敗しました");
     // ついでにフレーム投入 API も呼んでおく。
     let buf = I420Buffer::new(2, 2);
-    let frame = VideoFrame::from_i420(&buf, 1_000_000, 0);
+    let frame_buffer = buf.cast_to_video_frame_buffer();
+    let frame = VideoFrame::from_buffer(&frame_buffer, 1_000_000, 0);
     source.on_frame(&frame);
 
     // PeerConnection を作成し、トラック付きで transceiver を追加する。
@@ -1215,7 +1331,8 @@ fn custom_video_encoder_factory_create_and_encode_calls_callbacks() {
         .expect("custom encoder の作成に失敗しました");
 
     let buffer = I420Buffer::new(2, 2);
-    let frame = VideoFrame::from_i420(&buffer, 123, 0);
+    let frame_buffer = buffer.cast_to_video_frame_buffer();
+    let frame = VideoFrame::from_buffer(&frame_buffer, 123, 0);
     let mut frame_types = VideoFrameTypeVector::new(0);
     frame_types.push(VideoFrameType::Key);
     frame_types.push(VideoFrameType::Delta);
@@ -1285,8 +1402,8 @@ fn custom_video_encoder_get_encoder_info_roundtrip_all_fields() {
             {
                 let mut preferred = info.preferred_pixel_formats();
                 preferred.clear();
-                preferred.push(VideoFrameBufferType::I420);
-                preferred.push(VideoFrameBufferType::Nv12);
+                preferred.push(VideoFrameBufferKind::I420);
+                preferred.push(VideoFrameBufferKind::Nv12);
             }
 
             info.set_is_qp_trusted(Some(true));
@@ -1361,10 +1478,10 @@ fn custom_video_encoder_get_encoder_info_roundtrip_all_fields() {
 
     let mut preferred = info.preferred_pixel_formats();
     assert_eq!(preferred.len(), 2);
-    assert_eq!(preferred.get(0), Some(VideoFrameBufferType::I420));
-    assert_eq!(preferred.get(1), Some(VideoFrameBufferType::Nv12));
-    assert!(preferred.set(1, VideoFrameBufferType::I420A));
-    assert_eq!(preferred.get(1), Some(VideoFrameBufferType::I420A));
+    assert_eq!(preferred.get(0), Some(VideoFrameBufferKind::I420));
+    assert_eq!(preferred.get(1), Some(VideoFrameBufferKind::Nv12));
+    assert!(preferred.set(1, VideoFrameBufferKind::I420A));
+    assert_eq!(preferred.get(1), Some(VideoFrameBufferKind::I420A));
 
     assert_eq!(info.is_qp_trusted(), Some(true));
     assert_eq!(info.min_qp(), Some(9));
@@ -1681,7 +1798,8 @@ fn custom_video_encoder_register_and_encode_calls_encoded_image_and_codec_specif
     );
 
     let buffer = I420Buffer::new(2, 2);
-    let frame = VideoFrame::from_i420(&buffer, 123, 0);
+    let frame_buffer = buffer.cast_to_video_frame_buffer();
+    let frame = VideoFrame::from_buffer(&frame_buffer, 123, 0);
     assert_eq!(
         encoder.encode(frame.as_ref(), None),
         VideoCodecStatus::Unknown(88)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,9 +1,8 @@
 use super::*;
 use std::ptr::NonNull;
 use std::sync::{
-    Arc,
+    Arc, Mutex,
     atomic::{AtomicBool, Ordering},
-    Mutex,
 };
 use std::time::Duration;
 
@@ -244,6 +243,67 @@ fn i420_buffer_mutable_planes_and_video_frame_rtp_timestamp() {
 }
 
 #[test]
+fn nv12_buffer_planes_kind_and_to_i420() {
+    let width = 4;
+    let height = 3;
+    let mut buf = NV12Buffer::new(width, height);
+
+    assert_eq!(buf.width(), width);
+    assert_eq!(buf.height(), height);
+    assert_eq!(buf.y_data().len(), (buf.stride_y() * height) as usize);
+    assert_eq!(
+        buf.uv_data().len(),
+        (buf.stride_uv() as usize) * (height as usize).div_ceil(2)
+    );
+
+    for (i, v) in buf.y_data_mut().iter_mut().enumerate() {
+        *v = (i as u8).wrapping_add(0x10);
+    }
+    for uv in buf.uv_data_mut().chunks_exact_mut(2) {
+        uv[0] = 0x44;
+        uv[1] = 0x88;
+    }
+
+    let mut frame_buffer = buf.cast_to_video_frame_buffer();
+    assert_eq!(frame_buffer.kind(), VideoFrameBufferKind::Nv12);
+
+    let i420 = frame_buffer
+        .to_i420()
+        .expect("VideoFrameBuffer から I420Buffer への変換に失敗しました");
+    assert_eq!(i420.y_data(), buf.y_data());
+    assert!(i420.u_data().iter().all(|&v| v == 0x44));
+    assert!(i420.v_data().iter().all(|&v| v == 0x88));
+}
+
+#[test]
+fn nv12_buffer_crop_and_scale_from() {
+    let mut src = NV12Buffer::new(4, 4);
+    src.y_data_mut().fill(0x11);
+    for uv in src.uv_data_mut().chunks_exact_mut(2) {
+        uv[0] = 0x22;
+        uv[1] = 0x66;
+    }
+
+    let mut dst = NV12Buffer::new(2, 2);
+    dst.crop_and_scale_from(&src, 0, 0, 4, 4);
+
+    assert!(dst.y_data().iter().all(|&v| v == 0x11));
+    for uv in dst.uv_data().chunks_exact(2) {
+        assert_eq!(uv[0], 0x22);
+        assert_eq!(uv[1], 0x66);
+    }
+
+    let mut frame_buffer = dst.cast_to_video_frame_buffer();
+    assert_eq!(frame_buffer.kind(), VideoFrameBufferKind::Nv12);
+    let i420 = frame_buffer
+        .to_i420()
+        .expect("VideoFrameBuffer から I420Buffer への変換に失敗しました");
+    assert!(i420.y_data().iter().all(|&v| v == 0x11));
+    assert!(i420.u_data().iter().all(|&v| v == 0x22));
+    assert!(i420.v_data().iter().all(|&v| v == 0x66));
+}
+
+#[test]
 fn video_frame_buffer_handler_native_roundtrip() {
     struct NativeBufferHandler;
 
@@ -414,10 +474,7 @@ fn video_frame_buffer_handler_crop_and_scale_callback() {
                 scaled_width,
                 scaled_height,
             ));
-            Some(
-                I420Buffer::new(scaled_width, scaled_height)
-                    .cast_to_video_frame_buffer(),
-            )
+            Some(I420Buffer::new(scaled_width, scaled_height).cast_to_video_frame_buffer())
         }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -243,6 +243,24 @@ fn i420_buffer_mutable_planes_and_video_frame_rtp_timestamp() {
 }
 
 #[test]
+fn i420_buffer_chroma_dimensions_for_odd_size() {
+    let width = 5;
+    let height = 3;
+    let buf = I420Buffer::new(width, height);
+
+    assert_eq!(buf.chroma_width(), 3);
+    assert_eq!(buf.chroma_height(), 2);
+    assert_eq!(
+        buf.u_data().len(),
+        (buf.stride_u() as usize) * (buf.chroma_height() as usize)
+    );
+    assert_eq!(
+        buf.v_data().len(),
+        (buf.stride_v() as usize) * (buf.chroma_height() as usize)
+    );
+}
+
+#[test]
 fn nv12_buffer_planes_kind_and_to_i420() {
     let width = 4;
     let height = 3;
@@ -273,6 +291,20 @@ fn nv12_buffer_planes_kind_and_to_i420() {
     assert_eq!(i420.y_data(), buf.y_data());
     assert!(i420.u_data().iter().all(|&v| v == 0x44));
     assert!(i420.v_data().iter().all(|&v| v == 0x88));
+}
+
+#[test]
+fn nv12_buffer_chroma_dimensions_for_odd_size() {
+    let width = 5;
+    let height = 3;
+    let buf = NV12Buffer::new(width, height);
+
+    assert_eq!(buf.chroma_width(), 3);
+    assert_eq!(buf.chroma_height(), 2);
+    assert_eq!(
+        buf.uv_data().len(),
+        (buf.stride_uv() as usize) * (buf.chroma_height() as usize)
+    );
 }
 
 #[test]

--- a/webrtc/CMakeLists.txt
+++ b/webrtc/CMakeLists.txt
@@ -367,6 +367,7 @@ add_library(webrtc_c
     src/webrtc_c/api/video/encoded_image.cc
     src/webrtc_c/api/video/i420_buffer.cc
     src/webrtc_c/api/video/video_frame.cc
+    src/webrtc_c/api/video/video_frame_buffer.cc
     src/webrtc_c/api/video/video_sink_interface.cc
     src/webrtc_c/api/video/video_source_interface.cc
     src/webrtc_c/api/video_codecs/video_codec.cc

--- a/webrtc/CMakeLists.txt
+++ b/webrtc/CMakeLists.txt
@@ -366,6 +366,7 @@ add_library(webrtc_c
     src/webrtc_c/api/stats/rtc_stats_report.cc
     src/webrtc_c/api/video/encoded_image.cc
     src/webrtc_c/api/video/i420_buffer.cc
+    src/webrtc_c/api/video/nv12_buffer.cc
     src/webrtc_c/api/video/video_frame.cc
     src/webrtc_c/api/video/video_frame_buffer.cc
     src/webrtc_c/api/video/video_sink_interface.cc

--- a/webrtc/src/webrtc_c.h
+++ b/webrtc/src/webrtc_c.h
@@ -24,6 +24,7 @@
 #include "webrtc_c/api/stats/rtc_stats_report.h"
 #include "webrtc_c/api/video/encoded_image.h"
 #include "webrtc_c/api/video/i420_buffer.h"
+#include "webrtc_c/api/video/nv12_buffer.h"
 #include "webrtc_c/api/video/video_frame.h"
 #include "webrtc_c/api/video/video_frame_buffer.h"
 #include "webrtc_c/api/video/video_sink_interface.h"

--- a/webrtc/src/webrtc_c.h
+++ b/webrtc/src/webrtc_c.h
@@ -25,6 +25,7 @@
 #include "webrtc_c/api/video/encoded_image.h"
 #include "webrtc_c/api/video/i420_buffer.h"
 #include "webrtc_c/api/video/video_frame.h"
+#include "webrtc_c/api/video/video_frame_buffer.h"
 #include "webrtc_c/api/video/video_sink_interface.h"
 #include "webrtc_c/api/video/video_source_interface.h"
 #include "webrtc_c/api/video_codecs/sdp_video_format.h"

--- a/webrtc/src/webrtc_c/api/video/i420_buffer.cc
+++ b/webrtc/src/webrtc_c/api/video/i420_buffer.cc
@@ -37,6 +37,16 @@ WEBRTC_EXPORT int webrtc_I420Buffer_height(
   auto buf = reinterpret_cast<const webrtc::I420Buffer*>(self);
   return buf->height();
 }
+WEBRTC_EXPORT int webrtc_I420Buffer_chroma_width(
+    const struct webrtc_I420Buffer* self) {
+  auto buf = reinterpret_cast<const webrtc::I420Buffer*>(self);
+  return (buf->width() + 1) / 2;
+}
+WEBRTC_EXPORT int webrtc_I420Buffer_chroma_height(
+    const struct webrtc_I420Buffer* self) {
+  auto buf = reinterpret_cast<const webrtc::I420Buffer*>(self);
+  return (buf->height() + 1) / 2;
+}
 WEBRTC_EXPORT uint8_t* webrtc_I420Buffer_MutableDataY(
     struct webrtc_I420Buffer* self) {
   auto buf = reinterpret_cast<webrtc::I420Buffer*>(self);

--- a/webrtc/src/webrtc_c/api/video/i420_buffer.cc
+++ b/webrtc/src/webrtc_c/api/video/i420_buffer.cc
@@ -17,6 +17,10 @@
 
 extern "C" {
 WEBRTC_DEFINE_REFCOUNTED(webrtc_I420Buffer, webrtc::I420Buffer);
+WEBRTC_DEFINE_CAST_REFCOUNTED(webrtc_I420Buffer,
+                              webrtc_VideoFrameBuffer,
+                              webrtc::I420Buffer,
+                              webrtc::VideoFrameBuffer);
 WEBRTC_EXPORT struct webrtc_I420Buffer_refcounted* webrtc_I420Buffer_Create(
     int width,
     int height) {

--- a/webrtc/src/webrtc_c/api/video/i420_buffer.cc
+++ b/webrtc/src/webrtc_c/api/video/i420_buffer.cc
@@ -40,12 +40,12 @@ WEBRTC_EXPORT int webrtc_I420Buffer_height(
 WEBRTC_EXPORT int webrtc_I420Buffer_chroma_width(
     const struct webrtc_I420Buffer* self) {
   auto buf = reinterpret_cast<const webrtc::I420Buffer*>(self);
-  return (buf->width() + 1) / 2;
+  return buf->ChromaWidth();
 }
 WEBRTC_EXPORT int webrtc_I420Buffer_chroma_height(
     const struct webrtc_I420Buffer* self) {
   auto buf = reinterpret_cast<const webrtc::I420Buffer*>(self);
-  return (buf->height() + 1) / 2;
+  return buf->ChromaHeight();
 }
 WEBRTC_EXPORT uint8_t* webrtc_I420Buffer_MutableDataY(
     struct webrtc_I420Buffer* self) {

--- a/webrtc/src/webrtc_c/api/video/i420_buffer.h
+++ b/webrtc/src/webrtc_c/api/video/i420_buffer.h
@@ -13,6 +13,8 @@ extern "C" {
 // -------------------------
 
 WEBRTC_DECLARE_REFCOUNTED(webrtc_I420Buffer);
+struct webrtc_VideoFrameBuffer_refcounted;
+
 WEBRTC_EXPORT struct webrtc_I420Buffer_refcounted* webrtc_I420Buffer_Create(
     int width,
     int height);
@@ -30,6 +32,7 @@ WEBRTC_EXPORT int webrtc_I420Buffer_StrideU(struct webrtc_I420Buffer* self);
 WEBRTC_EXPORT int webrtc_I420Buffer_StrideV(struct webrtc_I420Buffer* self);
 WEBRTC_EXPORT void webrtc_I420Buffer_ScaleFrom(struct webrtc_I420Buffer* self,
                                                struct webrtc_I420Buffer* src);
+WEBRTC_DECLARE_CAST_REFCOUNTED(webrtc_I420Buffer, webrtc_VideoFrameBuffer);
 
 #if defined(__cplusplus)
 }

--- a/webrtc/src/webrtc_c/api/video/i420_buffer.h
+++ b/webrtc/src/webrtc_c/api/video/i420_buffer.h
@@ -21,6 +21,10 @@ WEBRTC_EXPORT struct webrtc_I420Buffer_refcounted* webrtc_I420Buffer_Create(
 WEBRTC_EXPORT int webrtc_I420Buffer_width(const struct webrtc_I420Buffer* self);
 WEBRTC_EXPORT int webrtc_I420Buffer_height(
     const struct webrtc_I420Buffer* self);
+WEBRTC_EXPORT int webrtc_I420Buffer_chroma_width(
+    const struct webrtc_I420Buffer* self);
+WEBRTC_EXPORT int webrtc_I420Buffer_chroma_height(
+    const struct webrtc_I420Buffer* self);
 WEBRTC_EXPORT uint8_t* webrtc_I420Buffer_MutableDataY(
     struct webrtc_I420Buffer* self);
 WEBRTC_EXPORT uint8_t* webrtc_I420Buffer_MutableDataU(

--- a/webrtc/src/webrtc_c/api/video/nv12_buffer.cc
+++ b/webrtc/src/webrtc_c/api/video/nv12_buffer.cc
@@ -40,12 +40,12 @@ WEBRTC_EXPORT int webrtc_NV12Buffer_height(
 WEBRTC_EXPORT int webrtc_NV12Buffer_chroma_width(
     const struct webrtc_NV12Buffer* self) {
   auto buf = reinterpret_cast<const webrtc::NV12Buffer*>(self);
-  return (buf->width() + 1) / 2;
+  return buf->ChromaWidth();
 }
 WEBRTC_EXPORT int webrtc_NV12Buffer_chroma_height(
     const struct webrtc_NV12Buffer* self) {
   auto buf = reinterpret_cast<const webrtc::NV12Buffer*>(self);
-  return (buf->height() + 1) / 2;
+  return buf->ChromaHeight();
 }
 WEBRTC_EXPORT uint8_t* webrtc_NV12Buffer_MutableDataY(
     struct webrtc_NV12Buffer* self) {

--- a/webrtc/src/webrtc_c/api/video/nv12_buffer.cc
+++ b/webrtc/src/webrtc_c/api/video/nv12_buffer.cc
@@ -37,6 +37,16 @@ WEBRTC_EXPORT int webrtc_NV12Buffer_height(
   auto buf = reinterpret_cast<const webrtc::NV12Buffer*>(self);
   return buf->height();
 }
+WEBRTC_EXPORT int webrtc_NV12Buffer_chroma_width(
+    const struct webrtc_NV12Buffer* self) {
+  auto buf = reinterpret_cast<const webrtc::NV12Buffer*>(self);
+  return (buf->width() + 1) / 2;
+}
+WEBRTC_EXPORT int webrtc_NV12Buffer_chroma_height(
+    const struct webrtc_NV12Buffer* self) {
+  auto buf = reinterpret_cast<const webrtc::NV12Buffer*>(self);
+  return (buf->height() + 1) / 2;
+}
 WEBRTC_EXPORT uint8_t* webrtc_NV12Buffer_MutableDataY(
     struct webrtc_NV12Buffer* self) {
   auto buf = reinterpret_cast<webrtc::NV12Buffer*>(self);

--- a/webrtc/src/webrtc_c/api/video/nv12_buffer.cc
+++ b/webrtc/src/webrtc_c/api/video/nv12_buffer.cc
@@ -1,0 +1,70 @@
+#include "nv12_buffer.h"
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// WebRTC
+#include <api/scoped_refptr.h>
+#include <api/video/nv12_buffer.h>
+
+#include "../../common.h"
+#include "../../common.impl.h"
+
+// -------------------------
+// webrtc::NV12Buffer
+// -------------------------
+
+extern "C" {
+WEBRTC_DEFINE_REFCOUNTED(webrtc_NV12Buffer, webrtc::NV12Buffer);
+WEBRTC_DEFINE_CAST_REFCOUNTED(webrtc_NV12Buffer,
+                              webrtc_VideoFrameBuffer,
+                              webrtc::NV12Buffer,
+                              webrtc::VideoFrameBuffer);
+WEBRTC_EXPORT struct webrtc_NV12Buffer_refcounted* webrtc_NV12Buffer_Create(
+    int width,
+    int height) {
+  auto buf = webrtc::NV12Buffer::Create(width, height);
+  return reinterpret_cast<struct webrtc_NV12Buffer_refcounted*>(buf.release());
+}
+WEBRTC_EXPORT int webrtc_NV12Buffer_width(
+    const struct webrtc_NV12Buffer* self) {
+  auto buf = reinterpret_cast<const webrtc::NV12Buffer*>(self);
+  return buf->width();
+}
+WEBRTC_EXPORT int webrtc_NV12Buffer_height(
+    const struct webrtc_NV12Buffer* self) {
+  auto buf = reinterpret_cast<const webrtc::NV12Buffer*>(self);
+  return buf->height();
+}
+WEBRTC_EXPORT uint8_t* webrtc_NV12Buffer_MutableDataY(
+    struct webrtc_NV12Buffer* self) {
+  auto buf = reinterpret_cast<webrtc::NV12Buffer*>(self);
+  return buf->MutableDataY();
+}
+WEBRTC_EXPORT uint8_t* webrtc_NV12Buffer_MutableDataUV(
+    struct webrtc_NV12Buffer* self) {
+  auto buf = reinterpret_cast<webrtc::NV12Buffer*>(self);
+  return buf->MutableDataUV();
+}
+WEBRTC_EXPORT int webrtc_NV12Buffer_StrideY(struct webrtc_NV12Buffer* self) {
+  auto buf = reinterpret_cast<webrtc::NV12Buffer*>(self);
+  return buf->StrideY();
+}
+WEBRTC_EXPORT int webrtc_NV12Buffer_StrideUV(struct webrtc_NV12Buffer* self) {
+  auto buf = reinterpret_cast<webrtc::NV12Buffer*>(self);
+  return buf->StrideUV();
+}
+WEBRTC_EXPORT void webrtc_NV12Buffer_CropAndScaleFrom(
+    struct webrtc_NV12Buffer* self,
+    struct webrtc_NV12Buffer* src,
+    int offset_x,
+    int offset_y,
+    int crop_width,
+    int crop_height) {
+  auto dst_buf = reinterpret_cast<webrtc::NV12Buffer*>(self);
+  auto src_buf = reinterpret_cast<webrtc::NV12Buffer*>(src);
+  dst_buf->CropAndScaleFrom(*src_buf, offset_x, offset_y, crop_width,
+                            crop_height);
+}
+}

--- a/webrtc/src/webrtc_c/api/video/nv12_buffer.h
+++ b/webrtc/src/webrtc_c/api/video/nv12_buffer.h
@@ -21,6 +21,10 @@ WEBRTC_EXPORT struct webrtc_NV12Buffer_refcounted* webrtc_NV12Buffer_Create(
 WEBRTC_EXPORT int webrtc_NV12Buffer_width(const struct webrtc_NV12Buffer* self);
 WEBRTC_EXPORT int webrtc_NV12Buffer_height(
     const struct webrtc_NV12Buffer* self);
+WEBRTC_EXPORT int webrtc_NV12Buffer_chroma_width(
+    const struct webrtc_NV12Buffer* self);
+WEBRTC_EXPORT int webrtc_NV12Buffer_chroma_height(
+    const struct webrtc_NV12Buffer* self);
 WEBRTC_EXPORT uint8_t* webrtc_NV12Buffer_MutableDataY(
     struct webrtc_NV12Buffer* self);
 WEBRTC_EXPORT uint8_t* webrtc_NV12Buffer_MutableDataUV(

--- a/webrtc/src/webrtc_c/api/video/nv12_buffer.h
+++ b/webrtc/src/webrtc_c/api/video/nv12_buffer.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "../../common.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// -------------------------
+// webrtc::NV12Buffer
+// -------------------------
+
+WEBRTC_DECLARE_REFCOUNTED(webrtc_NV12Buffer);
+struct webrtc_VideoFrameBuffer_refcounted;
+
+WEBRTC_EXPORT struct webrtc_NV12Buffer_refcounted* webrtc_NV12Buffer_Create(
+    int width,
+    int height);
+WEBRTC_EXPORT int webrtc_NV12Buffer_width(const struct webrtc_NV12Buffer* self);
+WEBRTC_EXPORT int webrtc_NV12Buffer_height(
+    const struct webrtc_NV12Buffer* self);
+WEBRTC_EXPORT uint8_t* webrtc_NV12Buffer_MutableDataY(
+    struct webrtc_NV12Buffer* self);
+WEBRTC_EXPORT uint8_t* webrtc_NV12Buffer_MutableDataUV(
+    struct webrtc_NV12Buffer* self);
+WEBRTC_EXPORT int webrtc_NV12Buffer_StrideY(struct webrtc_NV12Buffer* self);
+WEBRTC_EXPORT int webrtc_NV12Buffer_StrideUV(struct webrtc_NV12Buffer* self);
+WEBRTC_EXPORT void webrtc_NV12Buffer_CropAndScaleFrom(
+    struct webrtc_NV12Buffer* self,
+    struct webrtc_NV12Buffer* src,
+    int offset_x,
+    int offset_y,
+    int crop_width,
+    int crop_height);
+WEBRTC_DECLARE_CAST_REFCOUNTED(webrtc_NV12Buffer, webrtc_VideoFrameBuffer);
+
+#if defined(__cplusplus)
+}
+#endif

--- a/webrtc/src/webrtc_c/api/video/video_frame.cc
+++ b/webrtc/src/webrtc_c/api/video/video_frame.cc
@@ -9,11 +9,12 @@
 #include <api/scoped_refptr.h>
 #include <api/video/i420_buffer.h>
 #include <api/video/video_frame.h>
+#include <api/video/video_frame_buffer.h>
 #include <api/video/video_rotation.h>
 
 #include "../../common.h"
 #include "../../common.impl.h"
-#include "i420_buffer.h"
+#include "video_frame_buffer.h"
 
 // -------------------------
 // webrtc::VideoFrame
@@ -32,12 +33,13 @@ WEBRTC_EXPORT const int webrtc_VideoRotation_270 =
 
 WEBRTC_DEFINE_UNIQUE(webrtc_VideoFrame, webrtc::VideoFrame);
 WEBRTC_EXPORT struct webrtc_VideoFrame_unique* webrtc_VideoFrame_Create(
-    struct webrtc_I420Buffer_refcounted* buffer,
+    struct webrtc_VideoFrameBuffer_refcounted* buffer,
     int rotation,
     int64_t timestamp_us,
     uint32_t timestamp_rtp) {
-  webrtc::scoped_refptr<webrtc::I420Buffer> buf(
-      reinterpret_cast<webrtc::I420Buffer*>(buffer));
+  auto raw = webrtc_VideoFrameBuffer_refcounted_get(buffer);
+  webrtc::scoped_refptr<webrtc::VideoFrameBuffer> buf(
+      reinterpret_cast<webrtc::VideoFrameBuffer*>(raw));
   auto frame = std::make_unique<webrtc::VideoFrame>(
       webrtc::VideoFrame::Builder()
           .set_video_frame_buffer(buf)
@@ -72,10 +74,11 @@ WEBRTC_EXPORT int webrtc_VideoFrame_rotation(
   auto frame = reinterpret_cast<const webrtc::VideoFrame*>(self);
   return static_cast<int>(frame->rotation());
 }
-WEBRTC_EXPORT struct webrtc_I420Buffer_refcounted*
+WEBRTC_EXPORT struct webrtc_VideoFrameBuffer_refcounted*
 webrtc_VideoFrame_video_frame_buffer(const struct webrtc_VideoFrame* self) {
   auto frame = reinterpret_cast<const webrtc::VideoFrame*>(self);
-  auto buf = frame->video_frame_buffer()->ToI420();
-  return reinterpret_cast<struct webrtc_I420Buffer_refcounted*>(buf.release());
+  auto buf = frame->video_frame_buffer();
+  return reinterpret_cast<struct webrtc_VideoFrameBuffer_refcounted*>(
+      buf.release());
 }
 }

--- a/webrtc/src/webrtc_c/api/video/video_frame.cc
+++ b/webrtc/src/webrtc_c/api/video/video_frame.cc
@@ -49,6 +49,15 @@ WEBRTC_EXPORT struct webrtc_VideoFrame_unique* webrtc_VideoFrame_Create(
           .build());
   return reinterpret_cast<struct webrtc_VideoFrame_unique*>(frame.release());
 }
+WEBRTC_EXPORT struct webrtc_VideoFrame_unique* webrtc_VideoFrame_copy(
+    const struct webrtc_VideoFrame* self) {
+  auto frame = reinterpret_cast<const webrtc::VideoFrame*>(self);
+  if (frame == nullptr) {
+    return nullptr;
+  }
+  auto copied = std::make_unique<webrtc::VideoFrame>(*frame);
+  return reinterpret_cast<struct webrtc_VideoFrame_unique*>(copied.release());
+}
 WEBRTC_EXPORT int webrtc_VideoFrame_width(
     const struct webrtc_VideoFrame* self) {
   auto frame = reinterpret_cast<const webrtc::VideoFrame*>(self);

--- a/webrtc/src/webrtc_c/api/video/video_frame.h
+++ b/webrtc/src/webrtc_c/api/video/video_frame.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 
 #include "../../common.h"
-#include "i420_buffer.h"
+#include "video_frame_buffer.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -20,7 +20,7 @@ WEBRTC_EXPORT extern const int webrtc_VideoRotation_270;
 
 WEBRTC_DECLARE_UNIQUE(webrtc_VideoFrame);
 WEBRTC_EXPORT struct webrtc_VideoFrame_unique* webrtc_VideoFrame_Create(
-    struct webrtc_I420Buffer_refcounted* buffer,
+    struct webrtc_VideoFrameBuffer_refcounted* buffer,
     int rotation,
     int64_t timestamp_us,
     uint32_t timestamp_rtp);
@@ -33,7 +33,7 @@ WEBRTC_EXPORT uint32_t
 webrtc_VideoFrame_timestamp_rtp(const struct webrtc_VideoFrame* self);
 WEBRTC_EXPORT int webrtc_VideoFrame_rotation(
     const struct webrtc_VideoFrame* self);
-WEBRTC_EXPORT struct webrtc_I420Buffer_refcounted*
+WEBRTC_EXPORT struct webrtc_VideoFrameBuffer_refcounted*
 webrtc_VideoFrame_video_frame_buffer(const struct webrtc_VideoFrame* self);
 
 #if defined(__cplusplus)

--- a/webrtc/src/webrtc_c/api/video/video_frame.h
+++ b/webrtc/src/webrtc_c/api/video/video_frame.h
@@ -24,6 +24,8 @@ WEBRTC_EXPORT struct webrtc_VideoFrame_unique* webrtc_VideoFrame_Create(
     int rotation,
     int64_t timestamp_us,
     uint32_t timestamp_rtp);
+WEBRTC_EXPORT struct webrtc_VideoFrame_unique* webrtc_VideoFrame_copy(
+    const struct webrtc_VideoFrame* self);
 WEBRTC_EXPORT int webrtc_VideoFrame_width(const struct webrtc_VideoFrame* self);
 WEBRTC_EXPORT int webrtc_VideoFrame_height(
     const struct webrtc_VideoFrame* self);

--- a/webrtc/src/webrtc_c/api/video/video_frame_buffer.cc
+++ b/webrtc/src/webrtc_c/api/video/video_frame_buffer.cc
@@ -8,6 +8,7 @@
 #include <api/make_ref_counted.h>
 #include <api/scoped_refptr.h>
 #include <api/video/i420_buffer.h>
+#include <api/video/nv12_buffer.h>
 #include <api/video/video_frame_buffer.h>
 
 #include "../../common.h"
@@ -100,6 +101,8 @@ class VideoFrameBufferImpl : public webrtc::VideoFrameBuffer {
     return buffer;
   }
 
+  void* user_data() const { return user_data_; }
+
  private:
   webrtc_VideoFrameBuffer_cbs cbs_{};
   void* user_data_ = nullptr;
@@ -126,6 +129,40 @@ WEBRTC_EXPORT int webrtc_VideoFrameBuffer_height(
     const struct webrtc_VideoFrameBuffer* self) {
   auto buffer = reinterpret_cast<const webrtc::VideoFrameBuffer*>(self);
   return buffer->height();
+}
+
+WEBRTC_EXPORT void* webrtc_VideoFrameBuffer_get_user_data(
+    struct webrtc_VideoFrameBuffer* self) {
+  auto buffer = reinterpret_cast<webrtc::VideoFrameBuffer*>(self);
+  auto impl = dynamic_cast<VideoFrameBufferImpl*>(buffer);
+  if (impl == nullptr) {
+    return nullptr;
+  }
+  return impl->user_data();
+}
+
+WEBRTC_EXPORT struct webrtc_I420Buffer_refcounted*
+webrtc_VideoFrameBuffer_cast_to_webrtc_I420Buffer(
+    struct webrtc_VideoFrameBuffer* self) {
+  auto buffer = reinterpret_cast<webrtc::VideoFrameBuffer*>(self);
+  auto i420 = dynamic_cast<webrtc::I420Buffer*>(buffer);
+  if (i420 == nullptr) {
+    return nullptr;
+  }
+  webrtc::scoped_refptr<webrtc::I420Buffer> ref(i420);
+  return reinterpret_cast<struct webrtc_I420Buffer_refcounted*>(ref.release());
+}
+
+WEBRTC_EXPORT struct webrtc_NV12Buffer_refcounted*
+webrtc_VideoFrameBuffer_cast_to_webrtc_NV12Buffer(
+    struct webrtc_VideoFrameBuffer* self) {
+  auto buffer = reinterpret_cast<webrtc::VideoFrameBuffer*>(self);
+  auto nv12 = dynamic_cast<webrtc::NV12Buffer*>(buffer);
+  if (nv12 == nullptr) {
+    return nullptr;
+  }
+  webrtc::scoped_refptr<webrtc::NV12Buffer> ref(nv12);
+  return reinterpret_cast<struct webrtc_NV12Buffer_refcounted*>(ref.release());
 }
 
 WEBRTC_EXPORT struct webrtc_I420Buffer_refcounted* webrtc_VideoFrameBuffer_ToI420(

--- a/webrtc/src/webrtc_c/api/video/video_frame_buffer.cc
+++ b/webrtc/src/webrtc_c/api/video/video_frame_buffer.cc
@@ -1,0 +1,125 @@
+#include "video_frame_buffer.h"
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// WebRTC
+#include <api/make_ref_counted.h>
+#include <api/scoped_refptr.h>
+#include <api/video/i420_buffer.h>
+#include <api/video/video_frame_buffer.h>
+
+#include "../../common.h"
+#include "../../common.impl.h"
+#include "i420_buffer.h"
+
+namespace {
+
+class VideoFrameBufferImpl : public webrtc::VideoFrameBuffer {
+ public:
+  VideoFrameBufferImpl(const struct webrtc_VideoFrameBuffer_cbs* cbs,
+                       void* user_data)
+      : user_data_(user_data) {
+    if (cbs != nullptr) {
+      cbs_ = *cbs;
+    }
+  }
+
+  ~VideoFrameBufferImpl() override {
+    if (cbs_.OnDestroy != nullptr) {
+      cbs_.OnDestroy(user_data_);
+    }
+  }
+
+  Type type() const override {
+    if (cbs_.type == nullptr) {
+      return Type::kNative;
+    }
+    return static_cast<Type>(cbs_.type(user_data_));
+  }
+
+  int width() const override {
+    if (cbs_.width == nullptr) {
+      return 0;
+    }
+    return cbs_.width(user_data_);
+  }
+
+  int height() const override {
+    if (cbs_.height == nullptr) {
+      return 0;
+    }
+    return cbs_.height(user_data_);
+  }
+
+  webrtc::scoped_refptr<webrtc::I420BufferInterface> ToI420() override {
+    if (cbs_.ToI420 == nullptr) {
+      return nullptr;
+    }
+    auto raw_ref = cbs_.ToI420(user_data_);
+    if (raw_ref == nullptr) {
+      return nullptr;
+    }
+    auto raw = webrtc_I420Buffer_refcounted_get(raw_ref);
+    assert(raw != nullptr);
+    if (raw == nullptr) {
+      return nullptr;
+    }
+    auto i420 = reinterpret_cast<webrtc::I420Buffer*>(raw);
+    webrtc::scoped_refptr<webrtc::I420Buffer> buffer(i420);
+    webrtc_I420Buffer_Release(reinterpret_cast<struct webrtc_I420Buffer*>(raw));
+    return buffer;
+  }
+
+ private:
+  webrtc_VideoFrameBuffer_cbs cbs_{};
+  void* user_data_ = nullptr;
+};
+
+}  // namespace
+
+extern "C" {
+WEBRTC_DEFINE_REFCOUNTED(webrtc_VideoFrameBuffer, webrtc::VideoFrameBuffer);
+
+WEBRTC_EXPORT int webrtc_VideoFrameBuffer_type(
+    const struct webrtc_VideoFrameBuffer* self) {
+  auto buffer = reinterpret_cast<const webrtc::VideoFrameBuffer*>(self);
+  return static_cast<int>(buffer->type());
+}
+
+WEBRTC_EXPORT int webrtc_VideoFrameBuffer_width(
+    const struct webrtc_VideoFrameBuffer* self) {
+  auto buffer = reinterpret_cast<const webrtc::VideoFrameBuffer*>(self);
+  return buffer->width();
+}
+
+WEBRTC_EXPORT int webrtc_VideoFrameBuffer_height(
+    const struct webrtc_VideoFrameBuffer* self) {
+  auto buffer = reinterpret_cast<const webrtc::VideoFrameBuffer*>(self);
+  return buffer->height();
+}
+
+WEBRTC_EXPORT struct webrtc_I420Buffer_refcounted* webrtc_VideoFrameBuffer_ToI420(
+    struct webrtc_VideoFrameBuffer* self) {
+  auto buffer = reinterpret_cast<webrtc::VideoFrameBuffer*>(self);
+  auto i420 = buffer->ToI420();
+  if (i420 == nullptr) {
+    return nullptr;
+  }
+  auto copied = webrtc::I420Buffer::Copy(*i420);
+  if (copied == nullptr) {
+    return nullptr;
+  }
+  return reinterpret_cast<struct webrtc_I420Buffer_refcounted*>(copied.release());
+}
+
+WEBRTC_EXPORT struct webrtc_VideoFrameBuffer_refcounted*
+webrtc_VideoFrameBuffer_make_ref_counted(
+    const struct webrtc_VideoFrameBuffer_cbs* cbs,
+    void* user_data) {
+  auto impl = webrtc::make_ref_counted<VideoFrameBufferImpl>(cbs, user_data);
+  return reinterpret_cast<struct webrtc_VideoFrameBuffer_refcounted*>(
+      impl.release());
+}
+}

--- a/webrtc/src/webrtc_c/api/video/video_frame_buffer.cc
+++ b/webrtc/src/webrtc_c/api/video/video_frame_buffer.cc
@@ -72,6 +72,34 @@ class VideoFrameBufferImpl : public webrtc::VideoFrameBuffer {
     return buffer;
   }
 
+  webrtc::scoped_refptr<webrtc::VideoFrameBuffer> CropAndScale(
+      int offset_x,
+      int offset_y,
+      int crop_width,
+      int crop_height,
+      int scaled_width,
+      int scaled_height) override {
+    if (cbs_.CropAndScale == nullptr) {
+      return nullptr;
+    }
+    auto raw_ref = cbs_.CropAndScale(
+        reinterpret_cast<struct webrtc_VideoFrameBuffer*>(this), offset_x,
+        offset_y, crop_width, crop_height, scaled_width, scaled_height,
+        user_data_);
+    if (raw_ref == nullptr) {
+      return nullptr;
+    }
+    auto raw = webrtc_VideoFrameBuffer_refcounted_get(raw_ref);
+    assert(raw != nullptr);
+    if (raw == nullptr) {
+      return nullptr;
+    }
+    auto frame_buffer = reinterpret_cast<webrtc::VideoFrameBuffer*>(raw);
+    webrtc::scoped_refptr<webrtc::VideoFrameBuffer> buffer(frame_buffer);
+    webrtc_VideoFrameBuffer_Release(raw);
+    return buffer;
+  }
+
  private:
   webrtc_VideoFrameBuffer_cbs cbs_{};
   void* user_data_ = nullptr;
@@ -112,6 +140,55 @@ WEBRTC_EXPORT struct webrtc_I420Buffer_refcounted* webrtc_VideoFrameBuffer_ToI42
     return nullptr;
   }
   return reinterpret_cast<struct webrtc_I420Buffer_refcounted*>(copied.release());
+}
+
+WEBRTC_EXPORT struct webrtc_VideoFrameBuffer_refcounted*
+webrtc_VideoFrameBuffer_DefaultCropAndScale(struct webrtc_VideoFrameBuffer* self,
+                                            int offset_x,
+                                            int offset_y,
+                                            int crop_width,
+                                            int crop_height,
+                                            int scaled_width,
+                                            int scaled_height) {
+  auto buffer = reinterpret_cast<webrtc::VideoFrameBuffer*>(self);
+  auto scaled = buffer->webrtc::VideoFrameBuffer::CropAndScale(
+      offset_x, offset_y, crop_width, crop_height, scaled_width, scaled_height);
+  if (scaled == nullptr) {
+    return nullptr;
+  }
+  return reinterpret_cast<struct webrtc_VideoFrameBuffer_refcounted*>(
+      scaled.release());
+}
+
+WEBRTC_EXPORT struct webrtc_VideoFrameBuffer_refcounted*
+webrtc_VideoFrameBuffer_CropAndScale(struct webrtc_VideoFrameBuffer* self,
+                                     int offset_x,
+                                     int offset_y,
+                                     int crop_width,
+                                     int crop_height,
+                                     int scaled_width,
+                                     int scaled_height) {
+  auto buffer = reinterpret_cast<webrtc::VideoFrameBuffer*>(self);
+  auto scaled = buffer->CropAndScale(offset_x, offset_y, crop_width, crop_height,
+                                     scaled_width, scaled_height);
+  if (scaled == nullptr) {
+    return nullptr;
+  }
+  return reinterpret_cast<struct webrtc_VideoFrameBuffer_refcounted*>(
+      scaled.release());
+}
+
+WEBRTC_EXPORT struct webrtc_VideoFrameBuffer_refcounted* webrtc_VideoFrameBuffer_Scale(
+    struct webrtc_VideoFrameBuffer* self,
+    int scaled_width,
+    int scaled_height) {
+  auto buffer = reinterpret_cast<webrtc::VideoFrameBuffer*>(self);
+  auto scaled = buffer->Scale(scaled_width, scaled_height);
+  if (scaled == nullptr) {
+    return nullptr;
+  }
+  return reinterpret_cast<struct webrtc_VideoFrameBuffer_refcounted*>(
+      scaled.release());
 }
 
 WEBRTC_EXPORT struct webrtc_VideoFrameBuffer_refcounted*

--- a/webrtc/src/webrtc_c/api/video/video_frame_buffer.h
+++ b/webrtc/src/webrtc_c/api/video/video_frame_buffer.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "../../common.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// -------------------------
+// webrtc::VideoFrameBuffer
+// -------------------------
+
+WEBRTC_DECLARE_REFCOUNTED(webrtc_VideoFrameBuffer);
+
+struct webrtc_I420Buffer_refcounted;
+
+struct webrtc_VideoFrameBuffer_cbs {
+  int (*type)(void* user_data);
+  int (*width)(void* user_data);
+  int (*height)(void* user_data);
+  struct webrtc_I420Buffer_refcounted* (*ToI420)(void* user_data);
+  void (*OnDestroy)(void* user_data);
+};
+
+WEBRTC_EXPORT int webrtc_VideoFrameBuffer_type(
+    const struct webrtc_VideoFrameBuffer* self);
+WEBRTC_EXPORT int webrtc_VideoFrameBuffer_width(
+    const struct webrtc_VideoFrameBuffer* self);
+WEBRTC_EXPORT int webrtc_VideoFrameBuffer_height(
+    const struct webrtc_VideoFrameBuffer* self);
+WEBRTC_EXPORT struct webrtc_I420Buffer_refcounted* webrtc_VideoFrameBuffer_ToI420(
+    struct webrtc_VideoFrameBuffer* self);
+WEBRTC_EXPORT struct webrtc_VideoFrameBuffer_refcounted*
+webrtc_VideoFrameBuffer_make_ref_counted(
+    const struct webrtc_VideoFrameBuffer_cbs* cbs,
+    void* user_data);
+
+#if defined(__cplusplus)
+}
+#endif

--- a/webrtc/src/webrtc_c/api/video/video_frame_buffer.h
+++ b/webrtc/src/webrtc_c/api/video/video_frame_buffer.h
@@ -21,6 +21,14 @@ struct webrtc_VideoFrameBuffer_cbs {
   int (*width)(void* user_data);
   int (*height)(void* user_data);
   struct webrtc_I420Buffer_refcounted* (*ToI420)(void* user_data);
+  struct webrtc_VideoFrameBuffer_refcounted* (*CropAndScale)(struct webrtc_VideoFrameBuffer* self,
+                                                             int offset_x,
+                                                             int offset_y,
+                                                             int crop_width,
+                                                             int crop_height,
+                                                             int scaled_width,
+                                                             int scaled_height,
+                                                             void* user_data);
   void (*OnDestroy)(void* user_data);
 };
 
@@ -32,6 +40,26 @@ WEBRTC_EXPORT int webrtc_VideoFrameBuffer_height(
     const struct webrtc_VideoFrameBuffer* self);
 WEBRTC_EXPORT struct webrtc_I420Buffer_refcounted* webrtc_VideoFrameBuffer_ToI420(
     struct webrtc_VideoFrameBuffer* self);
+WEBRTC_EXPORT struct webrtc_VideoFrameBuffer_refcounted*
+webrtc_VideoFrameBuffer_DefaultCropAndScale(struct webrtc_VideoFrameBuffer* self,
+                                            int offset_x,
+                                            int offset_y,
+                                            int crop_width,
+                                            int crop_height,
+                                            int scaled_width,
+                                            int scaled_height);
+WEBRTC_EXPORT struct webrtc_VideoFrameBuffer_refcounted*
+webrtc_VideoFrameBuffer_CropAndScale(struct webrtc_VideoFrameBuffer* self,
+                                     int offset_x,
+                                     int offset_y,
+                                     int crop_width,
+                                     int crop_height,
+                                     int scaled_width,
+                                     int scaled_height);
+WEBRTC_EXPORT struct webrtc_VideoFrameBuffer_refcounted*
+webrtc_VideoFrameBuffer_Scale(struct webrtc_VideoFrameBuffer* self,
+                              int scaled_width,
+                              int scaled_height);
 WEBRTC_EXPORT struct webrtc_VideoFrameBuffer_refcounted*
 webrtc_VideoFrameBuffer_make_ref_counted(
     const struct webrtc_VideoFrameBuffer_cbs* cbs,

--- a/webrtc/src/webrtc_c/api/video/video_frame_buffer.h
+++ b/webrtc/src/webrtc_c/api/video/video_frame_buffer.h
@@ -15,6 +15,7 @@ extern "C" {
 WEBRTC_DECLARE_REFCOUNTED(webrtc_VideoFrameBuffer);
 
 struct webrtc_I420Buffer_refcounted;
+struct webrtc_NV12Buffer_refcounted;
 
 struct webrtc_VideoFrameBuffer_cbs {
   int (*type)(void* user_data);
@@ -38,6 +39,14 @@ WEBRTC_EXPORT int webrtc_VideoFrameBuffer_width(
     const struct webrtc_VideoFrameBuffer* self);
 WEBRTC_EXPORT int webrtc_VideoFrameBuffer_height(
     const struct webrtc_VideoFrameBuffer* self);
+WEBRTC_EXPORT void* webrtc_VideoFrameBuffer_get_user_data(
+    struct webrtc_VideoFrameBuffer* self);
+WEBRTC_EXPORT struct webrtc_I420Buffer_refcounted*
+webrtc_VideoFrameBuffer_cast_to_webrtc_I420Buffer(
+    struct webrtc_VideoFrameBuffer* self);
+WEBRTC_EXPORT struct webrtc_NV12Buffer_refcounted*
+webrtc_VideoFrameBuffer_cast_to_webrtc_NV12Buffer(
+    struct webrtc_VideoFrameBuffer* self);
 WEBRTC_EXPORT struct webrtc_I420Buffer_refcounted* webrtc_VideoFrameBuffer_ToI420(
     struct webrtc_VideoFrameBuffer* self);
 WEBRTC_EXPORT struct webrtc_VideoFrameBuffer_refcounted*

--- a/webrtc/src/whep.c
+++ b/webrtc/src/whep.c
@@ -144,8 +144,16 @@ static void AnsiRenderer_OnFrame(const struct webrtc_VideoFrame* frame,
   // width, height に合わせてリサイズ
   struct webrtc_I420Buffer_refcounted* buf =
       webrtc_I420Buffer_Create(renderer->width, renderer->height);
-  struct webrtc_I420Buffer_refcounted* src =
+  struct webrtc_VideoFrameBuffer_refcounted* frame_buf =
       webrtc_VideoFrame_video_frame_buffer(frame);
+  struct webrtc_I420Buffer_refcounted* src = webrtc_VideoFrameBuffer_ToI420(
+      webrtc_VideoFrameBuffer_refcounted_get(frame_buf));
+  webrtc_VideoFrameBuffer_Release(
+      webrtc_VideoFrameBuffer_refcounted_get(frame_buf));
+  if (src == NULL) {
+    webrtc_I420Buffer_Release(webrtc_I420Buffer_refcounted_get(buf));
+    return;
+  }
   webrtc_I420Buffer_ScaleFrom(webrtc_I420Buffer_refcounted_get(buf),
                               webrtc_I420Buffer_refcounted_get(src));
   webrtc_I420Buffer_Release(webrtc_I420Buffer_refcounted_get(src));

--- a/webrtc/src/whip.c
+++ b/webrtc/src/whip.c
@@ -343,8 +343,12 @@ void* _FakeVideoCapturer_CaptureThread(void* arg) {
     }
 
     int64_t timestamp_us = (now_ms - cap->start_time_ms) * 1000;
+    struct webrtc_VideoFrameBuffer_refcounted* buffer_for_frame =
+        webrtc_I420Buffer_refcounted_cast_to_webrtc_VideoFrameBuffer(buffer);
     struct webrtc_VideoFrame_unique* frame = webrtc_VideoFrame_Create(
-        buffer, webrtc_VideoRotation_0, timestamp_us, 0);
+        buffer_for_frame, webrtc_VideoRotation_0, timestamp_us, 0);
+    webrtc_VideoFrameBuffer_Release(
+        webrtc_VideoFrameBuffer_refcounted_get(buffer_for_frame));
     webrtc_I420Buffer_Release(webrtc_I420Buffer_refcounted_get(buffer));
 
     int adapted_width;
@@ -369,21 +373,34 @@ void* _FakeVideoCapturer_CaptureThread(void* arg) {
             webrtc_VideoFrame_width(webrtc_VideoFrame_unique_get(frame)) ||
         adapted_height !=
             webrtc_VideoFrame_height(webrtc_VideoFrame_unique_get(frame))) {
-      struct webrtc_I420Buffer_refcounted* buf =
+      struct webrtc_VideoFrameBuffer_refcounted* frame_buf =
           webrtc_VideoFrame_video_frame_buffer(
               webrtc_VideoFrame_unique_get(frame));
+      struct webrtc_I420Buffer_refcounted* buf = webrtc_VideoFrameBuffer_ToI420(
+          webrtc_VideoFrameBuffer_refcounted_get(frame_buf));
+      webrtc_VideoFrameBuffer_Release(
+          webrtc_VideoFrameBuffer_refcounted_get(frame_buf));
+      if (buf == NULL) {
+        webrtc_VideoFrame_unique_delete(frame);
+        webrtc_Thread_SleepMs(1);
+        continue;
+      }
       struct webrtc_I420Buffer_refcounted* scaled =
           webrtc_I420Buffer_Create(adapted_width, adapted_height);
       webrtc_I420Buffer_ScaleFrom(webrtc_I420Buffer_refcounted_get(scaled),
                                   webrtc_I420Buffer_refcounted_get(buf));
       webrtc_I420Buffer_Release(webrtc_I420Buffer_refcounted_get(buf));
       webrtc_VideoFrame_unique_delete(frame);
+      struct webrtc_VideoFrameBuffer_refcounted* scaled_for_frame =
+          webrtc_I420Buffer_refcounted_cast_to_webrtc_VideoFrameBuffer(scaled);
       frame = webrtc_VideoFrame_Create(
-          scaled, webrtc_VideoRotation_0,
+          scaled_for_frame, webrtc_VideoRotation_0,
           webrtc_TimestampAligner_TranslateTimestamp(
               webrtc_TimestampAligner_unique_get(cap->timestamp_aligner),
               timestamp_us, webrtc_TimeMillis() * 1000),
           0);
+      webrtc_VideoFrameBuffer_Release(
+          webrtc_VideoFrameBuffer_refcounted_get(scaled_for_frame));
       webrtc_I420Buffer_Release(webrtc_I420Buffer_refcounted_get(scaled));
     } else {
       // 翻訳したタイムスタンプに差し替え
@@ -391,12 +408,26 @@ void* _FakeVideoCapturer_CaptureThread(void* arg) {
           webrtc_TimestampAligner_unique_get(cap->timestamp_aligner),
           timestamp_us, webrtc_TimeMillis() * 1000);
       // VideoFrame は再生成
-      struct webrtc_I420Buffer_refcounted* buf =
+      struct webrtc_VideoFrameBuffer_refcounted* frame_buf =
           webrtc_VideoFrame_video_frame_buffer(
               webrtc_VideoFrame_unique_get(frame));
+      struct webrtc_I420Buffer_refcounted* buf = webrtc_VideoFrameBuffer_ToI420(
+          webrtc_VideoFrameBuffer_refcounted_get(frame_buf));
+      webrtc_VideoFrameBuffer_Release(
+          webrtc_VideoFrameBuffer_refcounted_get(frame_buf));
+      if (buf == NULL) {
+        webrtc_VideoFrame_unique_delete(frame);
+        webrtc_Thread_SleepMs(1);
+        continue;
+      }
       webrtc_VideoFrame_unique_delete(frame);
+      struct webrtc_VideoFrameBuffer_refcounted* buf_for_frame =
+          webrtc_I420Buffer_refcounted_cast_to_webrtc_VideoFrameBuffer(buf);
       frame =
-          webrtc_VideoFrame_Create(buf, webrtc_VideoRotation_0, translated, 0);
+          webrtc_VideoFrame_Create(buf_for_frame, webrtc_VideoRotation_0,
+                                   translated, 0);
+      webrtc_VideoFrameBuffer_Release(
+          webrtc_VideoFrameBuffer_refcounted_get(buf_for_frame));
       webrtc_I420Buffer_Release(webrtc_I420Buffer_refcounted_get(buf));
     }
 


### PR DESCRIPTION
```rust
struct MyBuffer {
    ...
}

impl VideoFrameBufferHandler for MyBuffer {
    ...
}

// これで VideoFrameBuffer として C++ とやり取りできる
let mut buffer = VideoFrameBuffer::new_with_handler(Box::new(MyBuffer { ... }));

// これで元の型を取り出せる
let my_buffer = unsafe { buffer.as_native_ref::<MyBuffer>() }.unwrap();
```
