### PR TITLE
logging ヘッダの書式を clang-format に合わせる

### DIFF
--- a/webrtc/src/webrtc_c/rtc_base/logging.h
+++ b/webrtc/src/webrtc_c/rtc_base/logging.h
@@ -131,9 +131,9 @@ WEBRTC_EXPORT void webrtc_LogMessage_Print(int severity,
 #define RTC_LOG_VERBOSE(fmt, ...)                                            \
   webrtc_LogMessage_Print(webrtc_LogSeverity_LS_VERBOSE, __FILE__, __LINE__, \
                           fmt, ##__VA_ARGS__)
-#define RTC_LOG_INFO(fmt, ...)                                            \
-  webrtc_LogMessage_Print(webrtc_LogSeverity_LS_INFO, __FILE__, __LINE__, \
-                          fmt, ##__VA_ARGS__)
+#define RTC_LOG_INFO(fmt, ...)                                                 \
+  webrtc_LogMessage_Print(webrtc_LogSeverity_LS_INFO, __FILE__, __LINE__, fmt, \
+                          ##__VA_ARGS__)
 #define RTC_LOG_WARNING(fmt, ...)                                            \
   webrtc_LogMessage_Print(webrtc_LogSeverity_LS_WARNING, __FILE__, __LINE__, \
                           fmt, ##__VA_ARGS__)


### PR DESCRIPTION
## 概要

pre-commit hook の clang-format 検査で失敗していた既存の書式崩れを直す。

## 変更内容

- `RTC_LOG_INFO` マクロの継続行を書式に合わせる
- 挙動の変更なし